### PR TITLE
AMBARI-24724. Remove ambari-metrics dependency on ambari-commons.

### DIFF
--- a/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics-assembly/pom.xml
@@ -54,7 +54,6 @@
     <storm.sink.jar>ambari-metrics-storm-sink-with-common-${project.version}.jar</storm.sink.jar>
     <flume.sink.jar>ambari-metrics-flume-sink-with-common-${project.version}.jar</flume.sink.jar>
     <kafka.sink.jar>ambari-metrics-kafka-sink-with-common-${project.version}.jar</kafka.sink.jar>
-    <ambari.commons.location>${monitor.dir}/target/ambari-python/site-packages/ambari_commons</ambari.commons.location>
   </properties>
 
   <build>
@@ -599,14 +598,6 @@
                       </sources>
                     </mapping>
                     <mapping>
-                      <directory>${resmonitor.install.dir}/ambari_commons</directory>
-                      <sources>
-                        <source>
-                          <location>${ambari.commons.location}</location>
-                        </source>
-                      </sources>
-                    </mapping>
-                    <mapping>
                       <directory>/var/lib/ambari-metrics-monitor/lib</directory>
                       <sources>
                         <source>
@@ -743,14 +734,6 @@
                   <mapper>
                     <type>perm</type>
                     <prefix>${resmonitor.install.dir}/psutil</prefix>
-                  </mapper>
-                </data>
-                <data>
-                  <type>directory</type>
-                  <src>${ambari.commons.location}</src>
-                  <mapper>
-                    <type>perm</type>
-                    <prefix>${resmonitor.install.dir}/ambari_commons</prefix>
                   </mapper>
                 </data>
                 <data>

--- a/ambari-metrics-assembly/src/main/assembly/monitor.xml
+++ b/ambari-metrics-assembly/src/main/assembly/monitor.xml
@@ -31,13 +31,6 @@
       <outputDirectory>site-packages/resource_monitoring</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/../../ambari-common/src/main/python/ambari_commons</directory>
-      <outputDirectory>site-packages/resource_monitoring/ambari_commons</outputDirectory>
-      <includes>
-        <include>**/*</include>
-      </includes>
-    </fileSet>
-    <fileSet>
       <directory>${monitor.dir}/conf/unix</directory>
       <outputDirectory>conf</outputDirectory>
       <includes>

--- a/ambari-metrics-host-monitoring/pom.xml
+++ b/ambari-metrics-host-monitoring/pom.xml
@@ -36,12 +36,6 @@
     <final.name>${project.artifactId}-${project.version}</final.name>
   </properties>
   <dependencies>
-    <dependency>
-      <groupId>org.apache.ambari</groupId>
-      <artifactId>ambari-python</artifactId>
-      <version>2.7.1.1</version>
-      <type>tar.gz</type>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/ambari-metrics-host-monitoring/pom.xml
+++ b/ambari-metrics-host-monitoring/pom.xml
@@ -182,25 +182,6 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <version>2.5.1</version>
-            <executions>
-              <execution>
-                <id>unpack-ambari-common</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>unpack-dependencies</goal>
-                </goals>
-                <configuration>
-                  <includeTypes>tar.gz</includeTypes>
-                  <includeArtifactIds>ambari-python</includeArtifactIds>
-                  <outputDirectory>target/ambari-python</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.7</version>
             <executions>

--- a/ambari-metrics-host-monitoring/pom.xml
+++ b/ambari-metrics-host-monitoring/pom.xml
@@ -124,7 +124,9 @@
             <exclude>conf/unix/metric_groups.conf</exclude>
             <exclude>conf/windows/metric_groups.conf</exclude>
             <exclude>src/main/python/psutil/**</exclude>
-            <exclude>.pydevproject</exclude>
+	    <exclude>.pydevproject</exclude>
+	    <!--Python Mock library (BSD license)-->
+	    <exclude>src/test/python/mock/**</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/ambari-metrics-host-monitoring/src/main/python/core/config_reader.py
+++ b/ambari-metrics-host-monitoring/src/main/python/core/config_reader.py
@@ -22,9 +22,6 @@ import ConfigParser
 import StringIO
 import json
 import os
-from ambari_commons import OSConst
-from ambari_commons.os_family_impl import OsFamilyImpl
-
 
 #
 # Abstraction for OS-dependent configuration defaults
@@ -39,7 +36,6 @@ class ConfigDefaults(object):
   def get_ca_certs_file_path(self):
     pass
 
-@OsFamilyImpl(os_family=OsFamilyImpl.DEFAULT)
 class ConfigDefaultsLinux(ConfigDefaults):
   def __init__(self):
     self._CONFIG_DIR = "/etc/ambari-metrics-monitor/conf/"
@@ -56,7 +52,7 @@ class ConfigDefaultsLinux(ConfigDefaults):
   def get_ca_certs_file_path(self):
     return self._CA_CERTS_FILE_PATH
 
-configDefaults = ConfigDefaults()
+configDefaults = ConfigDefaultsLinux()
 
 config = ConfigParser.RawConfigParser()
 

--- a/ambari-metrics-host-monitoring/src/main/python/core/stop_handler.py
+++ b/ambari-metrics-host-monitoring/src/main/python/core/stop_handler.py
@@ -19,15 +19,9 @@ limitations under the License.
 '''
 
 import logging
-import os
 import signal
 import threading
 import traceback
-
-from ambari_commons import OSConst, OSCheck
-from ambari_commons.exceptions import FatalException
-from ambari_commons.os_family_impl import OsFamilyImpl
-
 
 logger = logging.getLogger()
 
@@ -61,7 +55,6 @@ def debug(sig, frame):
   logger.info(message)
 
 
-@OsFamilyImpl(os_family=OsFamilyImpl.DEFAULT)
 class StopHandlerLinux(StopHandler):
   def __init__(self, stopEvent=None):
     # Event used to gracefully stop the process
@@ -86,10 +79,9 @@ class StopHandlerLinux(StopHandler):
 
 
 def bind_signal_handlers(new_handler=None):
-  if OSCheck.get_os_family() != OSConst.WINSRV_FAMILY:
-      signal.signal(signal.SIGINT, signal_handler)
-      signal.signal(signal.SIGTERM, signal_handler)
-      signal.signal(signal.SIGUSR1, debug)
+  signal.signal(signal.SIGINT, signal_handler)
+  signal.signal(signal.SIGTERM, signal_handler)
+  signal.signal(signal.SIGUSR1, debug)
 
   if new_handler is None:
     global _handler

--- a/ambari-metrics-host-monitoring/src/main/python/main.py
+++ b/ambari-metrics-host-monitoring/src/main/python/main.py
@@ -23,12 +23,9 @@ import logging.handlers
 import os
 import sys
 import signal
-from ambari_commons.os_utils import remove_file
-
 from core.controller import Controller
 from core.config_reader import Configuration, PID_OUT_FILE
 from core.stop_handler import bind_signal_handlers
-
 
 logger = logging.getLogger()
 
@@ -38,6 +35,7 @@ def save_pid(pid, pidfile):
   """
     Save pid to pidfile.
   """
+  pfile = None
   try:
     pfile = open(pidfile, "w")
     pfile.write("%s\n" % pid)
@@ -45,7 +43,8 @@ def save_pid(pid, pidfile):
     pass
   finally:
     try:
-      pfile.close()
+      if pfile:
+        pfile.close()
     except:
       pass
 
@@ -81,7 +80,7 @@ def server_process_main(stop_handler, scmStatus=None):
   #The controller thread finishes when the stop event is signaled
   controller.join()
 
-  remove_file(PID_OUT_FILE)
+  os.remove(PID_OUT_FILE)
   pass
 
 def _init_logging(config):

--- a/ambari-metrics-host-monitoring/src/main/python/psutil/build.py
+++ b/ambari-metrics-host-monitoring/src/main/python/psutil/build.py
@@ -18,7 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-from ambari_commons.subprocess32 import call
+from subprocess import call
 import sys
 import os
 import shutil

--- a/ambari-metrics-host-monitoring/src/main/python/psutil/psutil/__init__.py
+++ b/ambari-metrics-host-monitoring/src/main/python/psutil/psutil/__init__.py
@@ -44,7 +44,7 @@ import time
 import signal
 import warnings
 import errno
-from ambari_commons import subprocess32
+import subprocess
 try:
     import pwd
 except ImportError:
@@ -1163,14 +1163,14 @@ class Process(object):
 # =====================================================================
 
 class Popen(Process):
-    """A more convenient interface to stdlib subprocess32 module.
+    """A more convenient interface to stdlib subprocess module.
     It starts a sub process and deals with it exactly as when using
-    subprocess32.Popen class but in addition also provides all the
+    subprocess.Popen class but in addition also provides all the
     properties and methods of psutil.Process class as a unified
     interface:
 
       >>> import psutil
-      >>> from ambari_commons.subprocess32 import PIPE
+      >>> from subprocess import PIPE
       >>> p = psutil.Popen(["python", "-c", "print 'hi'"], stdout=PIPE)
       >>> p.name()
       'python'
@@ -1188,24 +1188,24 @@ class Popen(Process):
     For method names common to both classes such as kill(), terminate()
     and wait(), psutil.Process implementation takes precedence.
 
-    Unlike subprocess32.Popen this class pre-emptively checks wheter PID
+    Unlike subprocess.Popen this class pre-emptively checks wheter PID
     has been reused on send_signal(), terminate() and kill() so that
     you don't accidentally terminate another process, fixing
     http://bugs.python.org/issue6973.
 
     For a complete documentation refer to:
-    http://docs.python.org/library/subprocess32.html
+    http://docs.python.org/library/subprocess.html
     """
 
     def __init__(self, *args, **kwargs):
         # Explicitly avoid to raise NoSuchProcess in case the process
-        # spawned by subprocess32.Popen terminates too quickly, see:
+        # spawned by subprocess.Popen terminates too quickly, see:
         # https://code.google.com/p/psutil/issues/detail?id=193
-        self.__subproc = subprocess32.Popen(*args, **kwargs)
+        self.__subproc = subprocess.Popen(*args, **kwargs)
         self._init(self.__subproc.pid, _ignore_nsp=True)
 
     def __dir__(self):
-        return sorted(set(dir(Popen) + dir(subprocess32.Popen)))
+        return sorted(set(dir(Popen) + dir(subprocess.Popen)))
 
     def __getattribute__(self, name):
         try:

--- a/ambari-metrics-host-monitoring/src/main/python/psutil/psutil/_pssunos.py
+++ b/ambari-metrics-host-monitoring/src/main/python/psutil/psutil/_pssunos.py
@@ -9,7 +9,7 @@
 import errno
 import os
 import socket
-from ambari_commons import subprocess32
+import subprocess
 import sys
 
 from psutil import _common
@@ -91,7 +91,7 @@ def swap_memory():
     #     usr/src/cmd/swap/swap.c
     # ...nevertheless I can't manage to obtain the same numbers as 'swap'
     # cmdline utility, so let's parse its output (sigh!)
-    p = subprocess32.Popen(['swap', '-l', '-k'], stdout=subprocess32.PIPE)
+    p = subprocess.Popen(['swap', '-l', '-k'], stdout=subprocess.PIPE)
     stdout, stderr = p.communicate()
     if PY3:
         stdout = stdout.decode(sys.stdout.encoding)
@@ -433,8 +433,8 @@ class Process(object):
         # TODO: rewrite this in C (...but the damn netstat source code
         # does not include this part! Argh!!)
         cmd = "pfiles %s" % pid
-        p = subprocess32.Popen(cmd, shell=True, stdout=subprocess32.PIPE,
-                             stderr=subprocess32.PIPE)
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
         if PY3:
             stdout, stderr = [x.decode(sys.stdout.encoding)

--- a/ambari-metrics-host-monitoring/src/main/unix/ambari-python-wrap
+++ b/ambari-metrics-host-monitoring/src/main/unix/ambari-python-wrap
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export PYTHONPATH=/usr/lib/python2.6/site-packages:/usr/lib/python2.6/site-packages/ambari_commons:$PYTHONPATH
+export PYTHONPATH=/usr/lib/python2.6/site-packages:$PYTHONPATH
 
 # checking for default Python 2
 if [ -a /usr/bin/python2 ] && [ -z "$PYTHON" ]; then

--- a/ambari-metrics-host-monitoring/src/test/python/core/TestEmitter.py
+++ b/ambari-metrics-host-monitoring/src/test/python/core/TestEmitter.py
@@ -31,7 +31,6 @@ from spnego_kerberos_auth import SPNEGOKerberosAuth
 os_distro_value = ('Suse','11','Final')
 
 with patch("platform.linux_distribution", return_value = os_distro_value):
-  from ambari_commons import OSCheck
   from application_metric_map import ApplicationMetricMap
   from config_reader import Configuration
   from emitter import Emitter
@@ -41,7 +40,6 @@ logger = logging.getLogger()
 
 class TestEmitter(TestCase):
 
-  @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
   @patch.object(CachedHTTPConnection, "create_connection", new = MagicMock())
   @patch.object(CachedHTTPConnection, "request")
   @patch.object(CachedHTTPConnection, "getresponse")
@@ -63,7 +61,6 @@ class TestEmitter(TestCase):
     self.assertUrlData(request_mock)
 
 
-  @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
   @patch.object(CachedHTTPConnection, "create_connection", new = MagicMock())
   @patch.object(CachedHTTPConnection, "getresponse", new = MagicMock())
   @patch.object(CachedHTTPConnection, "request")
@@ -83,7 +80,6 @@ class TestEmitter(TestCase):
     self.assertEqual(request_mock.call_count, 3)
     self.assertUrlData(request_mock)
 
-  @patch.object(OSCheck, "os_distribution", new = MagicMock(return_value = os_distro_value))
   @patch.object(CachedHTTPConnection, "create_connection", new = MagicMock())
   @patch.object(SPNEGOKerberosAuth, "authenticate_handshake")
   @patch.object(CachedHTTPConnection, "getresponse")

--- a/ambari-metrics-host-monitoring/src/test/python/mock/LICENSE.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/LICENSE.txt
@@ -1,0 +1,26 @@
+Copyright (c) 2003-2012, Michael Foord
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ambari-metrics-host-monitoring/src/test/python/mock/MANIFEST.in
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt tox.ini tests/*.py
+recursive-include docs *.txt *.py *.png *.css *.html *.js

--- a/ambari-metrics-host-monitoring/src/test/python/mock/README.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/README.txt
@@ -1,0 +1,179 @@
+mock is a library for testing in Python. It allows you to replace parts of
+your system under test with mock objects and make assertions about how they
+have been used.
+
+mock is now part of the Python standard library, available as `unittest.mock
+<http://docs.python.org/py3k/library/unittest.mock.html#module-unittest.mock>`_
+in Python 3.3 onwards.
+
+mock provides a core `MagicMock` class removing the need to create a host of
+stubs throughout your test suite. After performing an action, you can make
+assertions about which methods / attributes were used and arguments they were
+called with. You can also specify return values and set needed attributes in
+the normal way.
+
+mock is tested on Python versions 2.5-2.7 and Python 3. mock is also tested
+with the latest versions of Jython and pypy.
+
+The mock module also provides utility functions / objects to assist with
+testing, particularly monkey patching.
+
+* `PDF documentation for 1.0.1
+  <http://www.voidspace.org.uk/downloads/mock-1.0.1.pdf>`_
+* `mock on google code (repository and issue tracker)
+  <http://code.google.com/p/mock/>`_
+* `mock documentation
+  <http://www.voidspace.org.uk/python/mock/>`_
+* `mock on PyPI <http://pypi.python.org/pypi/mock/>`_
+* `Mailing list (testing-in-python@lists.idyll.org)
+  <http://lists.idyll.org/listinfo/testing-in-python>`_
+
+Mock is very easy to use and is designed for use with
+`unittest <http://pypi.python.org/pypi/unittest2>`_. Mock is based on
+the 'action -> assertion' pattern instead of 'record -> replay' used by many
+mocking frameworks. See the `mock documentation`_ for full details.
+
+Mock objects create all attributes and methods as you access them and store
+details of how they have been used. You can configure them, to specify return
+values or limit what attributes are available, and then make assertions about
+how they have been used::
+
+    >>> from mock import Mock
+    >>> real = ProductionClass()
+    >>> real.method = Mock(return_value=3)
+    >>> real.method(3, 4, 5, key='value')
+    3
+    >>> real.method.assert_called_with(3, 4, 5, key='value')
+
+`side_effect` allows you to perform side effects, return different values or
+raise an exception when a mock is called::
+
+   >>> mock = Mock(side_effect=KeyError('foo'))
+   >>> mock()
+   Traceback (most recent call last):
+    ...
+   KeyError: 'foo'
+   >>> values = {'a': 1, 'b': 2, 'c': 3}
+   >>> def side_effect(arg):
+   ...     return values[arg]
+   ...
+   >>> mock.side_effect = side_effect
+   >>> mock('a'), mock('b'), mock('c')
+   (3, 2, 1)
+   >>> mock.side_effect = [5, 4, 3, 2, 1]
+   >>> mock(), mock(), mock()
+   (5, 4, 3)
+
+Mock has many other ways you can configure it and control its behaviour. For
+example the `spec` argument configures the mock to take its specification from
+another object. Attempting to access attributes or methods on the mock that
+don't exist on the spec will fail with an `AttributeError`.
+
+The `patch` decorator / context manager makes it easy to mock classes or
+objects in a module under test. The object you specify will be replaced with a
+mock (or other object) during the test and restored when the test ends::
+
+    >>> from mock import patch
+    >>> @patch('test_module.ClassName1')
+    ... @patch('test_module.ClassName2')
+    ... def test(MockClass2, MockClass1):
+    ...     test_module.ClassName1()
+    ...     test_module.ClassName2()
+
+    ...     assert MockClass1.called
+    ...     assert MockClass2.called
+    ...
+    >>> test()
+
+.. note::
+
+   When you nest patch decorators the mocks are passed in to the decorated
+   function in the same order they applied (the normal *python* order that
+   decorators are applied). This means from the bottom up, so in the example
+   above the mock for `test_module.ClassName2` is passed in first.
+
+   With `patch` it matters that you patch objects in the namespace where they
+   are looked up. This is normally straightforward, but for a quick guide
+   read `where to patch
+   <http://www.voidspace.org.uk/python/mock/patch.html#where-to-patch>`_.
+
+As well as a decorator `patch` can be used as a context manager in a with
+statement::
+
+    >>> with patch.object(ProductionClass, 'method') as mock_method:
+    ...     mock_method.return_value = None
+    ...     real = ProductionClass()
+    ...     real.method(1, 2, 3)
+    ...
+    >>> mock_method.assert_called_once_with(1, 2, 3)
+
+There is also `patch.dict` for setting values in a dictionary just during the
+scope of a test and restoring the dictionary to its original state when the
+test ends::
+
+   >>> foo = {'key': 'value'}
+   >>> original = foo.copy()
+   >>> with patch.dict(foo, {'newkey': 'newvalue'}, clear=True):
+   ...     assert foo == {'newkey': 'newvalue'}
+   ...
+   >>> assert foo == original
+
+Mock supports the mocking of Python magic methods. The easiest way of
+using magic methods is with the `MagicMock` class. It allows you to do
+things like::
+
+    >>> from mock import MagicMock
+    >>> mock = MagicMock()
+    >>> mock.__str__.return_value = 'foobarbaz'
+    >>> str(mock)
+    'foobarbaz'
+    >>> mock.__str__.assert_called_once_with()
+
+Mock allows you to assign functions (or other Mock instances) to magic methods
+and they will be called appropriately. The MagicMock class is just a Mock
+variant that has all of the magic methods pre-created for you (well - all the
+useful ones anyway).
+
+The following is an example of using magic methods with the ordinary Mock
+class::
+
+    >>> from mock import Mock
+    >>> mock = Mock()
+    >>> mock.__str__ = Mock(return_value = 'wheeeeee')
+    >>> str(mock)
+    'wheeeeee'
+
+For ensuring that the mock objects your tests use have the same api as the
+objects they are replacing, you can use "auto-speccing". Auto-speccing can
+be done through the `autospec` argument to patch, or the `create_autospec`
+function. Auto-speccing creates mock objects that have the same attributes
+and methods as the objects they are replacing, and any functions and methods
+(including constructors) have the same call signature as the real object.
+
+This ensures that your mocks will fail in the same way as your production
+code if they are used incorrectly::
+
+   >>> from mock import create_autospec
+   >>> def function(a, b, c):
+   ...     pass
+   ...
+   >>> mock_function = create_autospec(function, return_value='fishy')
+   >>> mock_function(1, 2, 3)
+   'fishy'
+   >>> mock_function.assert_called_once_with(1, 2, 3)
+   >>> mock_function('wrong arguments')
+   Traceback (most recent call last):
+    ...
+   TypeError: <lambda>() takes exactly 3 arguments (1 given)
+
+`create_autospec` can also be used on classes, where it copies the signature of
+the `__init__` method, and on callable objects where it copies the signature of
+the `__call__` method.
+
+The distribution contains tests and documentation. The tests require
+`unittest2 <http://pypi.python.org/pypi/unittest2>`_ to run on Python 2.5, 2.6
+or 3.1. For Python 2.7 and 3.2 they can be run with
+`python -m unittest discover`.
+
+Docs from the in-development version of `mock` can be found at
+`mock.readthedocs.org <http://mock.readthedocs.org>`_.

--- a/ambari-metrics-host-monitoring/src/test/python/mock/__init__.py
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Michael Foord'

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/changelog.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/changelog.txt
@@ -1,0 +1,737 @@
+.. currentmodule:: mock
+
+
+CHANGELOG
+=========
+
+2012/11/05 Version 1.0.1
+------------------------
+
+* Functions decorated with `patch` variants have a `__wrapped__` attribute
+  pointing to the original function. This brings compatibility with the
+  default behaviour in Python 3.3 (due to a new feature in `functools.wraps`).
+
+Note that due to changes in `tox`, `mock` is no longer tested with Python 2.4.
+The compatibility code has not been removed so it probably still works, but
+tests are no longer run.
+
+
+2012/10/07 Version 1.0.0
+------------------------
+
+No changes since 1.0.0 beta 1. This version has feature parity with
+`unittest.mock
+<http://docs.python.org/py3k/library/unittest.mock.html#module-unittest.mock>`_
+in Python 3.3.
+
+Full list of changes since 0.8:
+
+* `mocksignature`, along with the `mocksignature` argument to `patch`, removed
+* Support for deleting attributes (accessing deleted attributes will raise an
+  `AttributeError`)
+* Added the `mock_open` helper function for mocking the builtin `open`
+* `__class__` is assignable, so a mock can pass an `isinstance` check without
+  requiring a spec
+* Addition of `PropertyMock`, for mocking properties
+* `MagicMocks` made unorderable by default (in Python 3). The comparison
+  methods (other than equality and inequality) now return `NotImplemented`
+* Propagate traceback info to support subclassing of `_patch` by other
+  libraries
+* `create_autospec` works with attributes present in results of `dir` that
+  can't be fetched from the object's class. Contributed by Konstantine Rybnikov
+* Any exceptions in an iterable `side_effect` will be raised instead of
+  returned
+* In Python 3, `create_autospec` now supports keyword only arguments
+* Added `patch.stopall` method to stop all active patches created by `start`
+* BUGFIX: calling `MagicMock.reset_mock` wouldn't reset magic method mocks
+* BUGFIX: calling `reset_mock` on a `MagicMock` created with autospec could
+  raise an exception
+* BUGFIX: passing multiple spec arguments to patchers (`spec` , `spec_set` and
+  `autospec`) had unpredictable results, now it is an error
+* BUGFIX: using `spec=True` *and* `create=True` as arguments to patchers could
+  result in using `DEFAULT` as the spec. Now it is an error instead
+* BUGFIX: using `spec` or `autospec` arguments to patchers, along with
+  `spec_set=True` did not work correctly
+* BUGFIX: using an object that evaluates to False as a spec could be ignored
+* BUGFIX: a list as the `spec` argument to a patcher would always result in a
+  non-callable mock. Now if `__call__` is in the spec the mock is callable
+
+
+2012/07/13 Version 1.0.0 beta 1
+--------------------------------
+
+* Added `patch.stopall` method to stop all active patches created by `start`
+* BUGFIX: calling `MagicMock.reset_mock` wouldn't reset magic method mocks
+* BUGFIX: calling `reset_mock` on a `MagicMock` created with autospec could
+  raise an exception
+
+
+2012/05/04 Version 1.0.0 alpha 2
+--------------------------------
+
+* `PropertyMock` attributes are now standard `MagicMocks`
+* `create_autospec` works with attributes present in results of `dir` that
+  can't be fetched from the object's class. Contributed by Konstantine Rybnikov
+* Any exceptions in an iterable `side_effect` will be raised instead of
+  returned
+* In Python 3, `create_autospec` now supports keyword only arguments
+
+
+2012/03/25 Version 1.0.0 alpha 1
+--------------------------------
+
+The standard library version!
+
+* `mocksignature`, along with the `mocksignature` argument to `patch`, removed
+* Support for deleting attributes (accessing deleted attributes will raise an
+  `AttributeError`)
+* Added the `mock_open` helper function for mocking the builtin `open`
+* `__class__` is assignable, so a mock can pass an `isinstance` check without
+  requiring a spec
+* Addition of `PropertyMock`, for mocking properties
+* `MagicMocks` made unorderable by default (in Python 3). The comparison
+  methods (other than equality and inequality) now return `NotImplemented`
+* Propagate traceback info to support subclassing of `_patch` by other
+  libraries
+* BUGFIX: passing multiple spec arguments to patchers (`spec` , `spec_set` and
+  `autospec`) had unpredictable results, now it is an error
+* BUGFIX: using `spec=True` *and* `create=True` as arguments to patchers could
+  result in using `DEFAULT` as the spec. Now it is an error instead
+* BUGFIX: using `spec` or `autospec` arguments to patchers, along with
+  `spec_set=True` did not work correctly
+* BUGFIX: using an object that evaluates to False as a spec could be ignored
+* BUGFIX: a list as the `spec` argument to a patcher would always result in a
+  non-callable mock. Now if `__call__` is in the spec the mock is callable
+
+
+2012/02/13 Version 0.8.0
+------------------------
+
+The only changes since 0.8rc2 are:
+
+* Improved repr of :data:`sentinel` objects
+* :data:`ANY` can be used for comparisons against :data:`call` objects
+* The return value of `MagicMock.__iter__` method can be set to
+  any iterable and isn't required to be an iterator
+
+Full List of changes since 0.7:
+
+mock 0.8.0 is the last version that will support Python 2.4.
+
+* Addition of :attr:`~Mock.mock_calls` list for *all* calls (including magic
+  methods and chained calls)
+* :func:`patch` and :func:`patch.object` now create a :class:`MagicMock`
+  instead of a :class:`Mock` by default
+* The patchers (`patch`, `patch.object` and `patch.dict`), plus `Mock` and
+  `MagicMock`, take arbitrary keyword arguments for configuration
+* New mock method :meth:`~Mock.configure_mock` for setting attributes and
+  return values / side effects on the mock and its attributes
+* New mock assert methods :meth:`~Mock.assert_any_call` and
+  :meth:`~Mock.assert_has_calls`
+* Implemented :ref:`auto-speccing` (recursive, lazy speccing of mocks with
+  mocked signatures for functions/methods), as the `autospec` argument to
+  `patch`
+* Added the :func:`create_autospec` function for manually creating
+  'auto-specced' mocks
+* :func:`patch.multiple` for doing multiple patches in a single call, using
+  keyword arguments
+* Setting :attr:`~Mock.side_effect` to an iterable will cause calls to the mock
+  to return the next value from the iterable
+* New `new_callable` argument to `patch` and `patch.object` allowing you to
+  pass in a class or callable object (instead of `MagicMock`) that will be
+  called to replace the object being patched
+* Addition of :class:`NonCallableMock` and :class:`NonCallableMagicMock`, mocks
+  without a `__call__` method
+* Addition of :meth:`~Mock.mock_add_spec` method for adding (or changing) a
+  spec on an existing mock
+* Protocol methods on :class:`MagicMock` are magic mocks, and are created
+  lazily on first lookup. This means the result of calling a protocol method is
+  a `MagicMock` instead of a `Mock` as it was previously
+* Addition of :meth:`~Mock.attach_mock` method
+* Added :data:`ANY` for ignoring arguments in :meth:`~Mock.assert_called_with`
+  calls
+* Addition of :data:`call` helper object
+* Improved repr for mocks
+* Improved repr for :attr:`Mock.call_args` and entries in
+  :attr:`Mock.call_args_list`, :attr:`Mock.method_calls` and
+  :attr:`Mock.mock_calls`
+* Improved repr for :data:`sentinel` objects
+* `patch` lookup is done at use time not at decoration time
+* In Python 2.6 or more recent, `dir` on a mock will report all the dynamically
+  created attributes (or the full list of attributes if there is a spec) as
+  well as all the mock methods and attributes.
+* Module level :data:`FILTER_DIR` added to control whether `dir(mock)` filters
+  private attributes. `True` by default.
+* `patch.TEST_PREFIX` for controlling how patchers recognise test methods when
+  used to decorate a class
+* Support for using Java exceptions as a :attr:`~Mock.side_effect` on Jython
+* `Mock` call lists (`call_args_list`, `method_calls` & `mock_calls`) are now
+  custom list objects that allow membership tests for "sub lists" and have
+  a nicer representation if you `str` or `print` them
+* Mocks attached as attributes or return values to other mocks have calls
+  recorded in `method_calls` and `mock_calls` of the parent (unless a name is
+  already set on the child)
+* Improved failure messages for `assert_called_with` and
+  `assert_called_once_with`
+* The return value of the :class:`MagicMock` `__iter__` method can be set to
+  any iterable and isn't required to be an iterator
+* Added the Mock API (`assert_called_with` etc) to functions created by
+  :func:`mocksignature`
+* Tuples as well as lists can be used to specify allowed methods for `spec` &
+  `spec_set` arguments
+* Calling `stop` on an unstarted patcher fails with  a more meaningful error
+  message
+* Renamed the internal classes `Sentinel` and `SentinelObject` to prevent abuse
+* BUGFIX: an error creating a patch, with nested patch decorators, won't leave
+  patches in place
+* BUGFIX: `__truediv__` and `__rtruediv__` not available as magic methods on
+  mocks in Python 3
+* BUGFIX: `assert_called_with` / `assert_called_once_with` can be used with
+  `self` as a keyword argument
+* BUGFIX: when patching a class with an explicit spec / spec_set (not a
+  boolean) it applies "spec inheritance" to the return value of the created
+  mock (the "instance")
+* BUGFIX: remove the `__unittest` marker causing traceback truncation
+* Removal of deprecated `patch_object`
+* Private attributes `_name`, `_methods`, '_children', `_wraps` and `_parent`
+  (etc) renamed to reduce likelihood of clash with user attributes.
+* Added license file to the distribution
+
+
+2012/01/10 Version 0.8.0 release candidate 2
+--------------------------------------------
+
+* Removed the `configure` keyword argument to `create_autospec` and allow
+  arbitrary keyword arguments (for the `Mock` constructor) instead
+* Fixed `ANY` equality with some types in `assert_called_with` calls
+* Switched to a standard Sphinx theme (compatible with
+  `readthedocs.org <http://mock.readthedocs.org>`_)
+
+
+2011/12/29 Version 0.8.0 release candidate 1
+--------------------------------------------
+
+* `create_autospec` on the return value of a mocked class will use `__call__`
+  for the signature rather than `__init__`
+* Performance improvement instantiating `Mock` and `MagicMock`
+* Mocks used as magic methods have the same type as their parent instead of
+  being hardcoded to `MagicMock`
+
+Special thanks to Julian Berman for his help with diagnosing and improving
+performance in this release.
+
+
+2011/10/09 Version 0.8.0 beta 4
+-------------------------------
+
+* `patch` lookup is done at use time not at decoration time
+* When attaching a Mock to another Mock as a magic method, calls are recorded
+  in mock_calls
+* Addition of `attach_mock` method
+* Renamed the internal classes `Sentinel` and `SentinelObject` to prevent abuse
+* BUGFIX: various issues around circular references with mocks (setting a mock
+  return value to be itself etc)
+
+
+2011/08/15 Version 0.8.0 beta 3
+-------------------------------
+
+* Mocks attached as attributes or return values to other mocks have calls
+  recorded in `method_calls` and `mock_calls` of the parent (unless a name is
+  already set on the child)
+* Addition of `mock_add_spec` method for adding (or changing) a spec on an
+  existing mock
+* Improved repr for `Mock.call_args` and entries in `Mock.call_args_list`,
+  `Mock.method_calls` and `Mock.mock_calls`
+* Improved repr for mocks
+* BUGFIX: minor fixes in the way `mock_calls` is worked out,
+  especially for "intermediate" mocks in a call chain
+
+
+2011/08/05 Version 0.8.0 beta 2
+-------------------------------
+
+* Setting `side_effect` to an iterable will cause calls to the mock to return
+  the next value from the iterable
+* Added `assert_any_call` method
+* Moved `assert_has_calls` from call lists onto mocks
+* BUGFIX: `call_args` and all members of `call_args_list` are two tuples of
+  `(args, kwargs)` again instead of three tuples of `(name, args, kwargs)`
+
+
+2011/07/25 Version 0.8.0 beta 1
+-------------------------------
+
+* `patch.TEST_PREFIX` for controlling how patchers recognise test methods when
+  used to decorate a class
+* `Mock` call lists (`call_args_list`, `method_calls` & `mock_calls`) are now
+  custom list objects that allow membership tests for "sub lists" and have
+  an `assert_has_calls` method for unordered call checks
+* `callargs` changed to *always* be a three-tuple of `(name, args, kwargs)`
+* Addition of `mock_calls` list for *all* calls (including magic methods and
+  chained calls)
+* Extension of `call` object to support chained calls and `callargs` for better
+  comparisons with or without names. `call` object has a `call_list` method for
+  chained calls
+* Added the public `instance` argument to `create_autospec`
+* Support for using Java exceptions as a `side_effect` on Jython
+* Improved failure messages for `assert_called_with` and
+  `assert_called_once_with`
+* Tuples as well as lists can be used to specify allowed methods for `spec` &
+  `spec_set` arguments
+* BUGFIX: Fixed bug in `patch.multiple` for argument passing when creating
+  mocks
+* Added license file to the distribution
+
+
+2011/07/16 Version 0.8.0 alpha 2
+--------------------------------
+
+* `patch.multiple` for doing multiple patches in a single call, using keyword
+  arguments
+* New `new_callable` argument to `patch` and `patch.object` allowing you to
+  pass in a class or callable object (instead of `MagicMock`) that will be
+  called to replace the object being patched
+* Addition of `NonCallableMock` and `NonCallableMagicMock`, mocks without a
+  `__call__` method
+* Mocks created by `patch` have a `MagicMock` as the `return_value` where a
+  class is being patched
+* `create_autospec` can create non-callable mocks for non-callable objects.
+  `return_value` mocks of classes will be non-callable unless the class has
+  a `__call__` method
+* `autospec` creates a `MagicMock` without a spec for properties and slot
+  descriptors, because we don't know the type of object they return
+* Removed the "inherit" argument from `create_autospec`
+* Calling `stop` on an unstarted patcher fails with  a more meaningful error
+  message
+* BUGFIX: an error creating a patch, with nested patch decorators, won't leave
+  patches in place
+* BUGFIX: `__truediv__` and `__rtruediv__` not available as magic methods on
+  mocks in Python 3
+* BUGFIX: `assert_called_with` / `assert_called_once_with` can be used with
+  `self` as a keyword argument
+* BUGFIX: autospec for functions / methods with an argument named self that
+  isn't the first argument no longer broken
+* BUGFIX: when patching a class with an explicit spec / spec_set (not a
+  boolean) it applies "spec inheritance" to the return value of the created
+  mock (the "instance")
+* BUGFIX: remove the `__unittest` marker causing traceback truncation
+
+
+2011/06/14 Version 0.8.0 alpha 1
+--------------------------------
+
+mock 0.8.0 is the last version that will support Python 2.4.
+
+* The patchers (`patch`, `patch.object` and `patch.dict`), plus `Mock` and
+  `MagicMock`, take arbitrary keyword arguments for configuration
+* New mock method `configure_mock` for setting attributes and return values /
+  side effects on the mock and its attributes
+* In Python 2.6 or more recent, `dir` on a mock will report all the dynamically
+  created attributes (or the full list of attributes if there is a spec) as
+  well as all the mock methods and attributes.
+* Module level `FILTER_DIR` added to control whether `dir(mock)` filters
+  private attributes. `True` by default. Note that `vars(Mock())` can still be
+  used to get all instance attributes and `dir(type(Mock())` will still return
+  all the other attributes (irrespective of `FILTER_DIR`)
+* `patch` and `patch.object` now create a `MagicMock` instead of a `Mock` by
+  default
+* Added `ANY` for ignoring arguments in `assert_called_with` calls
+* Addition of `call` helper object
+* Protocol methods on `MagicMock` are magic mocks, and are created lazily on
+  first lookup. This means the result of calling a protocol method is a
+  MagicMock instead of a Mock as it was previously
+* Added the Mock API (`assert_called_with` etc) to functions created by
+  `mocksignature`
+* Private attributes `_name`, `_methods`, '_children', `_wraps` and `_parent`
+  (etc) renamed to reduce likelihood of clash with user attributes.
+* Implemented auto-speccing (recursive, lazy speccing of mocks with mocked
+  signatures for functions/methods)
+
+  Limitations:
+
+  - Doesn't mock magic methods or attributes (it creates MagicMocks, so the
+    magic methods are *there*, they just don't have the signature mocked nor
+    are attributes followed)
+  - Doesn't mock function / method attributes
+  - Uses object traversal on the objects being mocked to determine types - so
+    properties etc may be triggered
+  - The return value of mocked classes (the 'instance') has the same call
+    signature as the class __init__ (as they share the same spec)
+
+  You create auto-specced mocks by passing `autospec=True` to `patch`.
+
+  Note that attributes that are None are special cased and mocked without a
+  spec (so any attribute / method can be used). This is because None is
+  typically used as a default value for attributes that may be of some other
+  type, and as we don't know what type that may be we allow all access.
+
+  Note that the `autospec` option to `patch` obsoletes the `mocksignature`
+  option.
+
+* Added the `create_autospec` function for manually creating 'auto-specced'
+  mocks
+* Removal of deprecated `patch_object`
+
+
+2011/05/30 Version 0.7.2
+------------------------
+
+* BUGFIX: instances of list subclasses can now be used as mock specs
+* BUGFIX: MagicMock equality / inequality protocol methods changed to use the
+  default equality / inequality. This is done through a `side_effect` on
+  the mocks used for `__eq__` / `__ne__`
+
+
+2011/05/06 Version 0.7.1
+------------------------
+
+Package fixes contributed by Michael Fladischer. No code changes.
+
+* Include template in package
+* Use isolated binaries for the tox tests
+* Unset executable bit on docs
+* Fix DOS line endings in getting-started.txt
+
+
+2011/03/05 Version 0.7.0
+------------------------
+
+No API changes since 0.7.0 rc1. Many documentation changes including a stylish
+new `Sphinx theme <https://github.com/coordt/ADCtheme/>`_.
+
+The full set of changes since 0.6.0 are:
+
+* Python 3 compatibility
+* Ability to mock magic methods with `Mock` and addition of `MagicMock`
+  with pre-created magic methods
+* Addition of `mocksignature` and `mocksignature` argument to `patch` and
+  `patch.object`
+* Addition of `patch.dict` for changing dictionaries during a test
+* Ability to use `patch`, `patch.object` and `patch.dict` as class decorators
+* Renamed ``patch_object`` to `patch.object` (``patch_object`` is
+  deprecated)
+* Addition of soft comparisons: `call_args`, `call_args_list` and `method_calls`
+  now return tuple-like objects which compare equal even when empty args
+  or kwargs are skipped
+* patchers (`patch`, `patch.object` and `patch.dict`) have start and stop
+  methods
+* Addition of `assert_called_once_with` method
+* Mocks can now be named (`name` argument to constructor) and the name is used
+  in the repr
+* repr of a mock with a spec includes the class name of the spec
+* `assert_called_with` works with `python -OO`
+* New `spec_set` keyword argument to `Mock` and `patch`. If used,
+  attempting to *set* an attribute on a mock not on the spec will raise an
+  `AttributeError`
+* Mocks created with a spec can now pass `isinstance` tests (`__class__`
+  returns the type of the spec)
+* Added docstrings to all objects
+* Improved failure message for `Mock.assert_called_with` when the mock
+  has not been called at all
+* Decorated functions / methods have their docstring and `__module__`
+  preserved on Python 2.4.
+* BUGFIX: `mock.patch` now works correctly with certain types of objects that
+  proxy attribute access, like the django settings object
+* BUGFIX: mocks are now copyable (thanks to Ned Batchelder for reporting and
+  diagnosing this)
+* BUGFIX: `spec=True` works with old style classes
+* BUGFIX: ``help(mock)`` works now (on the module). Can no longer use ``__bases__``
+  as a valid sentinel name (thanks to Stephen Emslie for reporting and
+  diagnosing this)
+* BUGFIX: ``side_effect`` now works with ``BaseException`` exceptions like
+  ``KeyboardInterrupt``
+* BUGFIX: `reset_mock` caused infinite recursion when a mock is set as its own
+  return value
+* BUGFIX: patching the same object twice now restores the patches correctly
+* with statement tests now skipped on Python 2.4
+* Tests require unittest2 (or unittest2-py3k) to run
+* Tested with `tox <http://pypi.python.org/pypi/tox>`_ on Python 2.4 - 3.2,
+  jython and pypy (excluding 3.0)
+* Added 'build_sphinx' command to setup.py (requires setuptools or distribute)
+  Thanks to Florian Bauer
+* Switched from subversion to mercurial for source code control
+* `Konrad Delong <http://konryd.blogspot.com/>`_ added as co-maintainer
+
+
+2011/02/16 Version 0.7.0 RC 1
+-----------------------------
+
+Changes since beta 4:
+
+* Tested with jython, pypy and Python 3.2 and 3.1
+* Decorated functions / methods have their docstring and `__module__`
+  preserved on Python 2.4
+* BUGFIX: `mock.patch` now works correctly with certain types of objects that
+  proxy attribute access, like the django settings object
+* BUGFIX: `reset_mock` caused infinite recursion when a mock is set as its own
+  return value
+
+
+2010/11/12 Version 0.7.0 beta 4
+-------------------------------
+
+* patchers (`patch`, `patch.object` and `patch.dict`) have start and stop
+  methods
+* Addition of `assert_called_once_with` method
+* repr of a mock with a spec includes the class name of the spec
+* `assert_called_with` works with `python -OO`
+* New `spec_set` keyword argument to `Mock` and `patch`. If used,
+  attempting to *set* an attribute on a mock not on the spec will raise an
+  `AttributeError`
+* Attributes and return value of a `MagicMock` are `MagicMock` objects
+* Attempting to set an unsupported magic method now raises an `AttributeError`
+* `patch.dict` works as a class decorator
+* Switched from subversion to mercurial for source code control
+* BUGFIX: mocks are now copyable (thanks to Ned Batchelder for reporting and
+  diagnosing this)
+* BUGFIX: `spec=True` works with old style classes
+* BUGFIX: `mocksignature=True` can now patch instance methods via
+  `patch.object`
+
+
+2010/09/18 Version 0.7.0 beta 3
+-------------------------------
+
+* Using spec with :class:`MagicMock` only pre-creates magic methods in the spec
+* Setting a magic method on a mock with a ``spec`` can only be done if the
+  spec has that method
+* Mocks can now be named (`name` argument to constructor) and the name is used
+  in the repr
+* `mocksignature` can now be used with classes (signature based on `__init__`)
+  and callable objects (signature based on `__call__`)
+* Mocks created with a spec can now pass `isinstance` tests (`__class__`
+  returns the type of the spec)
+* Default numeric value for MagicMock is 1 rather than zero (because the
+  MagicMock bool defaults to True and 0 is False)
+* Improved failure message for :meth:`~Mock.assert_called_with` when the mock
+  has not been called at all
+* Adding the following to the set of supported magic methods:
+
+  - ``__getformat__`` and ``__setformat__``
+  - pickle methods
+  - ``__trunc__``, ``__ceil__`` and ``__floor__``
+  - ``__sizeof__``
+
+* Added 'build_sphinx' command to setup.py (requires setuptools or distribute)
+  Thanks to Florian Bauer
+* with statement tests now skipped on Python 2.4
+* Tests require unittest2 to run on Python 2.7
+* Improved several docstrings and documentation
+
+
+2010/06/23 Version 0.7.0 beta 2
+-------------------------------
+
+* :func:`patch.dict` works as a context manager as well as a decorator
+* ``patch.dict`` takes a string to specify dictionary as well as a dictionary
+  object. If a string is supplied the name specified is imported
+* BUGFIX: ``patch.dict`` restores dictionary even when an exception is raised
+
+
+2010/06/22 Version 0.7.0 beta 1
+-------------------------------
+
+* Addition of :func:`mocksignature`
+* Ability to mock magic methods
+* Ability to use ``patch`` and ``patch.object`` as class decorators
+* Renamed ``patch_object`` to :func:`patch.object` (``patch_object`` is
+  deprecated)
+* Addition of :class:`MagicMock` class with all magic methods pre-created for you
+* Python 3 compatibility (tested with 3.2 but should work with 3.0 & 3.1 as
+  well)
+* Addition of :func:`patch.dict` for changing dictionaries during a test
+* Addition of ``mocksignature`` argument to ``patch`` and ``patch.object``
+* ``help(mock)`` works now (on the module). Can no longer use ``__bases__``
+  as a valid sentinel name (thanks to Stephen Emslie for reporting and
+  diagnosing this)
+* Addition of soft comparisons: `call_args`, `call_args_list` and `method_calls`
+  now return tuple-like objects which compare equal even when empty args
+  or kwargs are skipped
+* Added docstrings.
+* BUGFIX: ``side_effect`` now works with ``BaseException`` exceptions like
+  ``KeyboardInterrupt``
+* BUGFIX: patching the same object twice now restores the patches correctly
+* The tests now require `unittest2 <http://pypi.python.org/pypi/unittest2>`_
+  to run
+* `Konrad Delong <http://konryd.blogspot.com/>`_ added as co-maintainer
+
+
+2009/08/22 Version 0.6.0
+------------------------
+
+* New test layout compatible with test discovery
+* Descriptors (static methods / class methods etc) can now be patched and
+  restored correctly
+* Mocks can raise exceptions when called by setting ``side_effect`` to an
+  exception class or instance
+* Mocks that wrap objects will not pass on calls to the underlying object if
+  an explicit return_value is set
+
+
+2009/04/17 Version 0.5.0
+------------------------
+
+* Made DEFAULT part of the public api.
+* Documentation built with Sphinx.
+* ``side_effect`` is now called with the same arguments as the mock is called with and
+  if returns a non-DEFAULT value that is automatically set as the ``mock.return_value``.
+* ``wraps`` keyword argument used for wrapping objects (and passing calls through to the wrapped object).
+* ``Mock.reset`` renamed to ``Mock.reset_mock``, as reset is a common API name.
+* ``patch`` / ``patch_object`` are now context managers and can be used with ``with``.
+* A new 'create' keyword argument to patch and patch_object that allows them to patch
+  (and unpatch) attributes that don't exist. (Potentially unsafe to use - it can allow
+  you to have tests that pass when they are testing an API that doesn't exist - use at
+  your own risk!)
+* The methods keyword argument to Mock has been removed and merged with spec. The spec
+  argument can now be a list of methods or an object to take the spec from.
+* Nested patches may now be applied in a different order (created mocks passed
+  in the opposite order). This is actually a bugfix.
+* patch and patch_object now take a spec keyword argument. If spec is
+  passed in as 'True' then the Mock created will take the object it is replacing
+  as its spec object. If the object being replaced is a class, then the return
+  value for the mock will also use the class as a spec.
+* A Mock created without a spec will not attempt to mock any magic methods / attributes
+  (they will raise an ``AttributeError`` instead).
+
+
+2008/10/12 Version 0.4.0
+------------------------
+
+* Default return value is now a new mock rather than None
+* return_value added as a keyword argument to the constructor
+* New method 'assert_called_with'
+* Added 'side_effect' attribute / keyword argument called when mock is called
+* patch decorator split into two decorators:
+
+    - ``patch_object`` which takes an object and an attribute name to patch
+      (plus optionally a value to patch with which defaults to a mock object)
+    - ``patch`` which takes a string specifying a target to patch; in the form
+      'package.module.Class.attribute'. (plus optionally a value to
+      patch with which defaults to a mock object)
+
+* Can now patch objects with ``None``
+* Change to patch for nose compatibility with error reporting in wrapped functions
+* Reset no longer clears children / return value etc - it just resets
+  call count and call args. It also calls reset on all children (and
+  the return value if it is a mock).
+
+Thanks to Konrad Delong, Kevin Dangoor and others for patches and suggestions.
+
+
+2007/12/03  Version 0.3.1
+-------------------------
+
+``patch`` maintains the name of decorated functions for compatibility with nose
+test autodiscovery.
+
+Tests decorated with ``patch`` that use the two argument form (implicit mock
+creation) will receive the mock(s) passed in as extra arguments.
+
+Thanks to Kevin Dangoor for these changes.
+
+
+2007/11/30  Version 0.3.0
+-------------------------
+
+Removed ``patch_module``. ``patch`` can now take a string as the first
+argument for patching modules.
+
+The third argument to ``patch`` is optional - a mock will be created by
+default if it is not passed in.
+
+
+2007/11/21  Version 0.2.1
+-------------------------
+
+Bug fix, allows reuse of functions decorated with ``patch`` and ``patch_module``.
+
+
+2007/11/20  Version 0.2.0
+-------------------------
+
+Added ``spec`` keyword argument for creating ``Mock`` objects from a
+specification object.
+
+Added ``patch`` and ``patch_module`` monkey patching decorators.
+
+Added ``sentinel`` for convenient access to unique objects.
+
+Distribution includes unit tests.
+
+
+2007/11/19  Version 0.1.0
+-------------------------
+
+Initial release.
+
+
+TODO and Limitations
+====================
+
+Contributions, bug reports and comments welcomed!
+
+Feature requests and bug reports are handled on the issue tracker:
+
+ * `mock issue tracker <http://code.google.com/p/mock/issues/list>`_
+
+`wraps` is not integrated with magic methods.
+
+`patch` could auto-do the patching in the constructor and unpatch in the
+destructor. This would be useful in itself, but violates TOOWTDI and would be
+unsafe for IronPython & PyPy (non-deterministic calling of destructors).
+Destructors aren't called in CPython where there are cycles, but a weak
+reference with a callback can be used to get round this.
+
+`Mock` has several attributes. This makes it unsuitable for mocking objects
+that use these attribute names. A way round this would be to provide methods
+that *hide* these attributes when needed. In 0.8 many, but not all, of these
+attributes are renamed to gain a `_mock` prefix, making it less likely that
+they will clash. Any outstanding attributes that haven't been modified with
+the prefix should be changed.
+
+If a patch is started using `patch.start` and then not stopped correctly then
+the unpatching is not done. Using weak references it would be possible to
+detect and fix this when the patch object itself is garbage collected. This
+would be tricky to get right though.
+
+When a `Mock` is created by `patch`, arbitrary keywords can be used to set
+attributes. If `patch` is created with a `spec`, and is replacing a class, then
+a `return_value` mock is created. The keyword arguments are not applied to the
+child mock, but could be.
+
+When mocking a class with `patch`, passing in `spec=True` or `autospec=True`,
+the mock class has an instance created from the same spec. Should this be the
+default behaviour for mocks anyway (mock return values inheriting the spec
+from their parent), or should it be controlled by an additional keyword
+argument (`inherit`) to the Mock constructor? `create_autospec` does this, so
+an additional keyword argument to Mock is probably unnecessary.
+
+The `mocksignature` argument to `patch` with a non `Mock` passed into
+`new_callable` will *probably* cause an error. Should it just be invalid?
+
+Note that `NonCallableMock` and `NonCallableMagicMock` still have the unused
+(and unusable) attributes: `return_value`, `side_effect`, `call_count`,
+`call_args` and `call_args_list`. These could be removed or raise errors on
+getting / setting. They also have the `assert_called_with` and
+`assert_called_once_with` methods. Removing these would be pointless as
+fetching them would create a mock (attribute) that could be called without
+error.
+
+Some outstanding technical debt. The way autospeccing mocks function
+signatures was copied and modified from `mocksignature`. This could all be
+refactored into one set of functions instead of two. The way we tell if
+patchers are started and if a patcher is being used for a `patch.multiple`
+call are both horrible. There are now a host of helper functions that should
+be rationalised. (Probably time to split mock into a package instead of a
+module.)
+
+Passing arbitrary keyword arguments to `create_autospec`, or `patch` with
+`autospec`, when mocking a *function* works fine. However, the arbitrary
+attributes are set on the created mock - but `create_autospec` returns a
+real function (which doesn't have those attributes). However, what is the use
+case for using autospec to create functions with attributes that don't exist
+on the original?
+
+`mocksignature`, plus the `call_args_list` and `method_calls` attributes of
+`Mock` could all be deprecated.

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/compare.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/compare.txt
@@ -1,0 +1,628 @@
+=========================
+ Mock Library Comparison
+=========================
+
+
+.. testsetup::
+
+    def assertEqual(a, b):
+        assert a == b, ("%r != %r" % (a, b))
+
+    def assertRaises(Exc, func):
+        try:
+            func()
+        except Exc:
+            return
+        assert False, ("%s not raised" % Exc)
+
+    sys.modules['somemodule'] = somemodule = mock.Mock(name='somemodule')
+    class SomeException(Exception):
+        some_method = method1 = method2 = None
+    some_other_object = SomeObject = SomeException
+
+
+A side-by-side comparison of how to accomplish some basic tasks with mock and
+some other popular Python mocking libraries and frameworks.
+
+These are:
+
+* `flexmock <http://pypi.python.org/pypi/flexmock>`_
+* `mox <http://pypi.python.org/pypi/mox>`_
+* `Mocker <http://niemeyer.net/mocker>`_
+* `dingus <http://pypi.python.org/pypi/dingus>`_
+* `fudge <http://pypi.python.org/pypi/fudge>`_
+
+Popular python mocking frameworks not yet represented here include
+`MiniMock <http://pypi.python.org/pypi/MiniMock>`_.
+
+`pMock <http://pmock.sourceforge.net/>`_ (last release 2004 and doesn't import
+in recent versions of Python) and
+`python-mock <http://python-mock.sourceforge.net/>`_ (last release 2005) are
+intentionally omitted.
+
+.. note::
+
+    A more up to date, and tested for all mock libraries (only the mock
+    examples on this page can be executed as doctests) version of this
+    comparison is maintained by Gary Bernhardt:
+
+    * `Python Mock Library Comparison
+      <http://garybernhardt.github.com/python-mock-comparison/>`_
+
+This comparison is by no means complete, and also may not be fully idiomatic
+for all the libraries represented. *Please* contribute corrections, missing
+comparisons, or comparisons for additional libraries to the `mock issue
+tracker <https://code.google.com/p/mock/issues/list>`_.
+
+This comparison page was originally created by the `Mox project
+<https://code.google.com/p/pymox/wiki/MoxComparison>`_ and then extended for
+`flexmock and mock <http://has207.github.com/flexmock/compare.html>`_ by
+Herman Sheremetyev. Dingus examples written by `Gary Bernhadt
+<http://garybernhardt.github.com/python-mock-comparison/>`_. fudge examples
+provided by `Kumar McMillan <http://farmdev.com/>`_.
+
+.. note::
+
+    The examples tasks here were originally created by Mox which is a mocking
+    *framework* rather than a library like mock. The tasks shown naturally
+    exemplify tasks that frameworks are good at and not the ones they make
+    harder. In particular you can take a `Mock` or `MagicMock` object and use
+    it in any way you want with no up-front configuration. The same is also
+    true for Dingus.
+
+    The examples for mock here assume version 0.7.0.
+
+
+Simple fake object
+~~~~~~~~~~~~~~~~~~
+
+.. doctest::
+
+    >>> # mock
+    >>> my_mock = mock.Mock()
+    >>> my_mock.some_method.return_value = "calculated value"
+    >>> my_mock.some_attribute = "value"
+    >>> assertEqual("calculated value", my_mock.some_method())
+    >>> assertEqual("value", my_mock.some_attribute)
+
+::
+
+    # Flexmock
+    mock = flexmock(some_method=lambda: "calculated value", some_attribute="value")
+    assertEqual("calculated value", mock.some_method())
+    assertEqual("value", mock.some_attribute)
+
+    # Mox
+    mock = mox.MockAnything()
+    mock.some_method().AndReturn("calculated value")
+    mock.some_attribute = "value"
+    mox.Replay(mock)
+    assertEqual("calculated value", mock.some_method())
+    assertEqual("value", mock.some_attribute)
+
+    # Mocker
+    mock = mocker.mock()
+    mock.some_method()
+    mocker.result("calculated value")
+    mocker.replay()
+    mock.some_attribute = "value"
+    assertEqual("calculated value", mock.some_method())
+    assertEqual("value", mock.some_attribute)
+
+::
+
+    >>> # Dingus
+    >>> my_dingus = dingus.Dingus(some_attribute="value",
+    ...                           some_method__returns="calculated value")
+    >>> assertEqual("calculated value", my_dingus.some_method())
+    >>> assertEqual("value", my_dingus.some_attribute)
+
+::
+
+    >>> # fudge
+    >>> my_fake = (fudge.Fake()
+    ...            .provides('some_method')
+    ...            .returns("calculated value")
+    ...            .has_attr(some_attribute="value"))
+    ...
+    >>> assertEqual("calculated value", my_fake.some_method())
+    >>> assertEqual("value", my_fake.some_attribute)
+
+
+Simple mock
+~~~~~~~~~~~
+
+.. doctest::
+
+    >>> # mock
+    >>> my_mock = mock.Mock()
+    >>> my_mock.some_method.return_value = "value"
+    >>> assertEqual("value", my_mock.some_method())
+    >>> my_mock.some_method.assert_called_once_with()
+
+::
+
+    # Flexmock
+    mock = flexmock()
+    mock.should_receive("some_method").and_return("value").once
+    assertEqual("value", mock.some_method())
+
+    # Mox
+    mock = mox.MockAnything()
+    mock.some_method().AndReturn("value")
+    mox.Replay(mock)
+    assertEqual("value", mock.some_method())
+    mox.Verify(mock)
+
+    # Mocker
+    mock = mocker.mock()
+    mock.some_method()
+    mocker.result("value")
+    mocker.replay()
+    assertEqual("value", mock.some_method())
+    mocker.verify()
+
+::
+
+    >>> # Dingus
+    >>> my_dingus = dingus.Dingus(some_method__returns="value")
+    >>> assertEqual("value", my_dingus.some_method())
+    >>> assert my_dingus.some_method.calls().once()
+
+::
+
+    >>> # fudge
+    >>> @fudge.test
+    ... def test():
+    ...     my_fake = (fudge.Fake()
+    ...                .expects('some_method')
+    ...                .returns("value")
+    ...                .times_called(1))
+    ...
+    >>> test()
+    Traceback (most recent call last):
+    ...
+    AssertionError: fake:my_fake.some_method() was not called
+
+
+Creating partial mocks
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. doctest::
+
+    >>> # mock
+    >>> SomeObject.some_method = mock.Mock(return_value='value')
+    >>> assertEqual("value", SomeObject.some_method())
+
+::
+
+    # Flexmock
+    flexmock(SomeObject).should_receive("some_method").and_return('value')
+    assertEqual("value", mock.some_method())
+
+    # Mox
+    mock = mox.MockObject(SomeObject)
+    mock.some_method().AndReturn("value")
+    mox.Replay(mock)
+    assertEqual("value", mock.some_method())
+    mox.Verify(mock)
+
+    # Mocker
+    mock = mocker.mock(SomeObject)
+    mock.Get()
+    mocker.result("value")
+    mocker.replay()
+    assertEqual("value", mock.some_method())
+    mocker.verify()
+
+::
+
+    >>> # Dingus
+    >>> object = SomeObject
+    >>> object.some_method = dingus.Dingus(return_value="value")
+    >>> assertEqual("value", object.some_method())
+
+::
+
+    >>> # fudge
+    >>> fake = fudge.Fake().is_callable().returns("<fudge-value>")
+    >>> with fudge.patched_context(SomeObject, 'some_method', fake):
+    ...     s = SomeObject()
+    ...     assertEqual("<fudge-value>", s.some_method())
+    ...
+
+
+Ensure calls are made in specific order
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. doctest::
+
+    >>> # mock
+    >>> my_mock = mock.Mock(spec=SomeObject)
+    >>> my_mock.method1()
+    <Mock name='mock.method1()' id='...'>
+    >>> my_mock.method2()
+    <Mock name='mock.method2()' id='...'>
+    >>> assertEqual(my_mock.mock_calls, [call.method1(), call.method2()])
+
+::
+
+    # Flexmock
+    mock = flexmock(SomeObject)
+    mock.should_receive('method1').once.ordered.and_return('first thing')
+    mock.should_receive('method2').once.ordered.and_return('second thing')
+
+    # Mox
+    mock = mox.MockObject(SomeObject)
+    mock.method1().AndReturn('first thing')
+    mock.method2().AndReturn('second thing')
+    mox.Replay(mock)
+    mox.Verify(mock)
+
+    # Mocker
+    mock = mocker.mock()
+    with mocker.order():
+        mock.method1()
+        mocker.result('first thing')
+        mock.method2()
+        mocker.result('second thing')
+        mocker.replay()
+        mocker.verify()
+
+::
+
+    >>> # Dingus
+    >>> my_dingus = dingus.Dingus()
+    >>> my_dingus.method1()
+    <Dingus ...>
+    >>> my_dingus.method2()
+    <Dingus ...>
+    >>> assertEqual(['method1', 'method2'], [call.name for call in my_dingus.calls])
+
+::
+
+    >>> # fudge
+    >>> @fudge.test
+    ... def test():
+    ...     my_fake = (fudge.Fake()
+    ...                .remember_order()
+    ...                .expects('method1')
+    ...                .expects('method2'))
+    ...     my_fake.method2()
+    ...     my_fake.method1()
+    ...
+    >>> test()
+    Traceback (most recent call last):
+    ...
+    AssertionError: Call #1 was fake:my_fake.method2(); Expected: #1 fake:my_fake.method1(), #2 fake:my_fake.method2(), end
+
+
+Raising exceptions
+~~~~~~~~~~~~~~~~~~
+
+.. doctest::
+
+    >>> # mock
+    >>> my_mock = mock.Mock()
+    >>> my_mock.some_method.side_effect = SomeException("message")
+    >>> assertRaises(SomeException, my_mock.some_method)
+
+::
+
+    # Flexmock
+    mock = flexmock()
+    mock.should_receive("some_method").and_raise(SomeException("message"))
+    assertRaises(SomeException, mock.some_method)
+
+    # Mox
+    mock = mox.MockAnything()
+    mock.some_method().AndRaise(SomeException("message"))
+    mox.Replay(mock)
+    assertRaises(SomeException, mock.some_method)
+    mox.Verify(mock)
+
+    # Mocker
+    mock = mocker.mock()
+    mock.some_method()
+    mocker.throw(SomeException("message"))
+    mocker.replay()
+    assertRaises(SomeException, mock.some_method)
+    mocker.verify()
+
+::
+
+    >>> # Dingus
+    >>> my_dingus = dingus.Dingus()
+    >>> my_dingus.some_method = dingus.exception_raiser(SomeException)
+    >>> assertRaises(SomeException, my_dingus.some_method)
+
+::
+
+    >>> # fudge
+    >>> my_fake = (fudge.Fake()
+    ...            .is_callable()
+    ...            .raises(SomeException("message")))
+    ...
+    >>> my_fake()
+    Traceback (most recent call last):
+    ...
+    SomeException: message
+
+
+Override new instances of a class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. doctest::
+
+    >>> # mock
+    >>> with mock.patch('somemodule.Someclass') as MockClass:
+    ...     MockClass.return_value = some_other_object
+    ...     assertEqual(some_other_object, somemodule.Someclass())
+    ...
+
+
+::
+
+    # Flexmock
+    flexmock(some_module.SomeClass, new_instances=some_other_object)
+    assertEqual(some_other_object, some_module.SomeClass())
+
+    # Mox
+    # (you will probably have mox.Mox() available as self.mox in a real test)
+    mox.Mox().StubOutWithMock(some_module, 'SomeClass', use_mock_anything=True)
+    some_module.SomeClass().AndReturn(some_other_object)
+    mox.ReplayAll()
+    assertEqual(some_other_object, some_module.SomeClass())
+
+    # Mocker
+    instance = mocker.mock()
+    klass = mocker.replace(SomeClass, spec=None)
+    klass('expected', 'args')
+    mocker.result(instance)
+
+::
+
+    >>> # Dingus
+    >>> MockClass = dingus.Dingus(return_value=some_other_object)
+    >>> with dingus.patch('somemodule.SomeClass', MockClass):
+    ...     assertEqual(some_other_object, somemodule.SomeClass())
+    ...
+
+::
+
+    >>> # fudge
+    >>> @fudge.patch('somemodule.SomeClass')
+    ... def test(FakeClass):
+    ...     FakeClass.is_callable().returns(some_other_object)
+    ...     assertEqual(some_other_object, somemodule.SomeClass())
+    ...
+    >>> test()
+
+
+Call the same method multiple times
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    You don't need to do *any* configuration to call `mock.Mock()` methods
+    multiple times. Attributes like `call_count`, `call_args_list` and
+    `method_calls` provide various different ways of making assertions about
+    how the mock was used.
+
+.. doctest::
+
+    >>> # mock
+    >>> my_mock = mock.Mock()
+    >>> my_mock.some_method()
+    <Mock name='mock.some_method()' id='...'>
+    >>> my_mock.some_method()
+    <Mock name='mock.some_method()' id='...'>
+    >>> assert my_mock.some_method.call_count >= 2
+
+::
+
+    # Flexmock # (verifies that the method gets called at least twice)
+    flexmock(some_object).should_receive('some_method').at_least.twice
+
+    # Mox
+    # (does not support variable number of calls, so you need to create a new entry for each explicit call)
+    mock = mox.MockObject(some_object)
+    mock.some_method(mox.IgnoreArg(), mox.IgnoreArg())
+    mock.some_method(mox.IgnoreArg(), mox.IgnoreArg())
+    mox.Replay(mock)
+    mox.Verify(mock)
+
+    # Mocker
+    # (TODO)
+
+::
+
+    >>> # Dingus
+    >>> my_dingus = dingus.Dingus()
+    >>> my_dingus.some_method()
+    <Dingus ...>
+    >>> my_dingus.some_method()
+    <Dingus ...>
+    >>> assert len(my_dingus.calls('some_method')) == 2
+
+::
+
+    >>> # fudge
+    >>> @fudge.test
+    ... def test():
+    ...     my_fake = fudge.Fake().expects('some_method').times_called(2)
+    ...     my_fake.some_method()
+    ...
+    >>> test()
+    Traceback (most recent call last):
+    ...
+    AssertionError: fake:my_fake.some_method() was called 1 time(s). Expected 2.
+
+
+Mock chained methods
+~~~~~~~~~~~~~~~~~~~~
+
+.. doctest::
+
+    >>> # mock
+    >>> my_mock = mock.Mock()
+    >>> method3 = my_mock.method1.return_value.method2.return_value.method3
+    >>> method3.return_value = 'some value'
+    >>> assertEqual('some value', my_mock.method1().method2().method3(1, 2))
+    >>> method3.assert_called_once_with(1, 2)
+
+::
+
+    # Flexmock
+    # (intermediate method calls are automatically assigned to temporary fake objects
+    # and can be called with any arguments)
+    flexmock(some_object).should_receive(
+        'method1.method2.method3'
+    ).with_args(arg1, arg2).and_return('some value')
+    assertEqual('some_value', some_object.method1().method2().method3(arg1, arg2))
+
+::
+
+    # Mox
+    mock = mox.MockObject(some_object)
+    mock2 = mox.MockAnything()
+    mock3 = mox.MockAnything()
+    mock.method1().AndReturn(mock1)
+    mock2.method2().AndReturn(mock2)
+    mock3.method3(arg1, arg2).AndReturn('some_value')
+    self.mox.ReplayAll()
+    assertEqual("some_value", some_object.method1().method2().method3(arg1, arg2))
+    self.mox.VerifyAll()
+
+    # Mocker
+    # (TODO)
+
+::
+
+    >>> # Dingus
+    >>> my_dingus = dingus.Dingus()
+    >>> method3 = my_dingus.method1.return_value.method2.return_value.method3
+    >>> method3.return_value = 'some value'
+    >>> assertEqual('some value', my_dingus.method1().method2().method3(1, 2))
+    >>> assert method3.calls('()', 1, 2).once()
+
+::
+
+    >>> # fudge
+    >>> @fudge.test
+    ... def test():
+    ...     my_fake = fudge.Fake()
+    ...     (my_fake
+    ...      .expects('method1')
+    ...      .returns_fake()
+    ...      .expects('method2')
+    ...      .returns_fake()
+    ...      .expects('method3')
+    ...      .with_args(1, 2)
+    ...      .returns('some value'))
+    ...     assertEqual('some value', my_fake.method1().method2().method3(1, 2))
+    ...
+    >>> test()
+
+
+Mocking a context manager
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Examples for mock, Dingus and fudge only (so far):
+
+.. doctest::
+
+    >>> # mock
+    >>> my_mock = mock.MagicMock()
+    >>> with my_mock:
+    ...     pass
+    ...
+    >>> my_mock.__enter__.assert_called_with()
+    >>> my_mock.__exit__.assert_called_with(None, None, None)
+
+::
+
+
+    >>> # Dingus (nothing special here; all dinguses are "magic mocks")
+    >>> my_dingus = dingus.Dingus()
+    >>> with my_dingus:
+    ...     pass
+    ...
+    >>> assert my_dingus.__enter__.calls()
+    >>> assert my_dingus.__exit__.calls('()', None, None, None)
+
+::
+
+    >>> # fudge
+    >>> my_fake = fudge.Fake().provides('__enter__').provides('__exit__')
+    >>> with my_fake:
+    ...     pass
+    ...
+
+
+Mocking the builtin open used as a context manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Example for mock only (so far):
+
+.. doctest::
+
+    >>> # mock
+    >>> my_mock = mock.MagicMock()
+    >>> with mock.patch('__builtin__.open', my_mock):
+    ...     manager = my_mock.return_value.__enter__.return_value
+    ...     manager.read.return_value = 'some data'
+    ...     with open('foo') as h:
+    ...         data = h.read()
+    ...
+    >>> data
+    'some data'
+    >>> my_mock.assert_called_once_with('foo')
+
+*or*:
+
+.. doctest::
+
+    >>> # mock
+    >>> with mock.patch('__builtin__.open') as my_mock:
+    ...     my_mock.return_value.__enter__ = lambda s: s
+    ...     my_mock.return_value.__exit__ = mock.Mock()
+    ...     my_mock.return_value.read.return_value = 'some data'
+    ...     with open('foo') as h:
+    ...         data = h.read()
+    ...
+    >>> data
+    'some data'
+    >>> my_mock.assert_called_once_with('foo')
+
+::
+
+    >>> # Dingus
+    >>> my_dingus = dingus.Dingus()
+    >>> with dingus.patch('__builtin__.open', my_dingus):
+    ...     file_ = open.return_value.__enter__.return_value
+    ...     file_.read.return_value = 'some data'
+    ...     with open('foo') as h:
+    ...         data = f.read()
+    ...
+    >>> data
+    'some data'
+    >>> assert my_dingus.calls('()', 'foo').once()
+
+::
+
+    >>> # fudge
+    >>> from contextlib import contextmanager
+    >>> from StringIO import StringIO
+    >>> @contextmanager
+    ... def fake_file(filename):
+    ...     yield StringIO('sekrets')
+    ...
+    >>> with fudge.patch('__builtin__.open') as fake_open:
+    ...     fake_open.is_callable().calls(fake_file)
+    ...     with open('/etc/password') as f:
+    ...         data = f.read()
+    ...
+    fake:__builtin__.open
+    >>> data
+    'sekrets'

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/conf.py
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/conf.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+#
+# Mock documentation build configuration file, created by
+# sphinx-quickstart on Mon Nov 17 18:12:00 2008.
+#
+# This file is execfile()d with the current directory set to its containing dir.
+#
+# The contents of this file are pickled, so don't put values in the namespace
+# that aren't pickleable (module imports are okay, they're removed automatically).
+#
+# All configuration values have a default value; values that are commented out
+# serve to show the default value.
+
+import sys, os
+sys.path.insert(0, os.path.abspath('..'))
+from mock import __version__
+
+# If your extensions are in another directory, add it here. If the directory
+# is relative to the documentation root, use os.path.abspath to make it
+# absolute, like shown here.
+#sys.path.append(os.path.abspath('some/directory'))
+
+# General configuration
+# ---------------------
+
+# Add any Sphinx extension module names here, as strings. They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = ['sphinx.ext.doctest']
+
+doctest_global_setup = """
+import os
+import sys
+import mock
+from mock import * # yeah, I know :-/
+import unittest2
+import __main__
+
+if os.getcwd() not in sys.path:
+    sys.path.append(os.getcwd())
+
+# keep a reference to __main__
+sys.modules['__main'] = __main__
+
+class ProxyModule(object):
+    def __init__(self):
+        self.__dict__ = globals()
+
+sys.modules['__main__'] = ProxyModule()
+"""
+
+doctest_global_cleanup = """
+sys.modules['__main__'] = sys.modules['__main']
+"""
+
+html_theme = 'nature'
+html_theme_options = {}
+
+# Add any paths that contain templates here, relative to this directory.
+#templates_path = ['_templates']
+
+# The suffix of source filenames.
+source_suffix = '.txt'
+
+# The master toctree document.
+master_doc = 'index'
+
+# General substitutions.
+project = u'Mock'
+copyright = u'2007-2012, Michael Foord & the mock team'
+
+# The default replacements for |version| and |release|, also used in various
+# other places throughout the built documents.
+#
+# The short X.Y version.
+version = __version__[:3]
+# The full version, including alpha/beta/rc tags.
+release = __version__
+
+# There are two options for replacing |today|: either, you set today to some
+# non-false value, then it is used:
+#today = ''
+# Else, today_fmt is used as the format for a strftime call.
+today_fmt = '%B %d, %Y'
+
+# List of documents that shouldn't be included in the build.
+#unused_docs = []
+
+# List of directories, relative to source directories, that shouldn't be searched
+# for source files.
+exclude_trees = []
+
+# The reST default role (used for this markup: `text`) to use for all documents.
+#default_role = None
+
+# If true, '()' will be appended to :func: etc. cross-reference text.
+#add_function_parentheses = True
+
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+add_module_names = False
+
+# If true, sectionauthor and moduleauthor directives will be shown in the
+# output. They are ignored by default.
+#show_authors = False
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'friendly'
+
+
+# Options for HTML output
+# -----------------------
+
+# The style sheet to use for HTML and HTML Help pages. A file of that name
+# must exist either in Sphinx' static/ path, or in one of the custom paths
+# given in html_static_path.
+#html_style = 'adctheme.css'
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+#html_title = None
+
+# A shorter title for the navigation bar.  Default is the same as html_title.
+#html_short_title = None
+
+# The name of an image file (relative to this directory) to place at the top
+# of the sidebar.
+#html_logo = None
+
+# The name of an image file (within the static path) to use as favicon of the
+# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# pixels large.
+#html_favicon = None
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+#html_static_path = ['_static']
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+html_last_updated_fmt = '%b %d, %Y'
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+#html_use_smartypants = True
+
+# Custom sidebar templates, maps document names to template names.
+#html_sidebars = {}
+
+# Additional templates that should be rendered to pages, maps page names to
+# template names.
+#html_additional_pages = {}
+
+# If false, no module index is generated.
+html_use_modindex = False
+
+# If false, no index is generated.
+#html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+#html_split_index = False
+
+# If true, the reST sources are included in the HTML build as _sources/<name>.
+#html_copy_source = True
+
+# If true, an OpenSearch description file will be output, and all pages will
+# contain a <link> tag referring to it.  The value of this option must be the
+# base URL from which the finished HTML is served.
+#html_use_opensearch = ''
+
+# If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
+#html_file_suffix = ''
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = 'Mockdoc'
+
+
+# Options for LaTeX output
+# ------------------------
+
+# The paper size ('letter' or 'a4').
+#latex_paper_size = 'letter'
+
+# The font size ('10pt', '11pt' or '12pt').
+latex_font_size = '12pt'
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, document class [howto/manual]).
+latex_documents = [
+  ('index', 'Mock.tex', u'Mock Documentation',
+   u'Michael Foord', 'manual'),
+]
+
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+#latex_logo = None
+
+# For "manual" documents, if this is true, then toplevel headings are parts,
+# not chapters.
+#latex_use_parts = False
+
+# Additional stuff for the LaTeX preamble.
+#latex_preamble = ''
+
+# Documents to append as an appendix to all manuals.
+#latex_appendices = []
+
+# If false, no module index is generated.
+latex_use_modindex = False

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/examples.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/examples.txt
@@ -1,0 +1,1063 @@
+.. _further-examples:
+
+==================
+ Further Examples
+==================
+
+.. currentmodule:: mock
+
+.. testsetup::
+
+    from datetime import date
+
+    BackendProvider = Mock()
+    sys.modules['mymodule'] = mymodule = Mock(name='mymodule')
+
+    def grob(val):
+        "First frob and then clear val"
+        mymodule.frob(val)
+        val.clear()
+
+    mymodule.frob = lambda val: val
+    mymodule.grob = grob
+    mymodule.date = date
+
+    class TestCase(unittest2.TestCase):
+        def run(self):
+            result = unittest2.TestResult()
+            out = unittest2.TestCase.run(self, result)
+            assert result.wasSuccessful()
+
+    from mock import inPy3k
+
+
+
+For comprehensive examples, see the unit tests included in the full source
+distribution.
+
+Here are some more examples for some slightly more advanced scenarios than in
+the :ref:`getting started <getting-started>` guide.
+
+
+Mocking chained calls
+=====================
+
+Mocking chained calls is actually straightforward with mock once you
+understand the :attr:`~Mock.return_value` attribute. When a mock is called for
+the first time, or you fetch its `return_value` before it has been called, a
+new `Mock` is created.
+
+This means that you can see how the object returned from a call to a mocked
+object has been used by interrogating the `return_value` mock:
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> mock().foo(a=2, b=3)
+    <Mock name='mock().foo()' id='...'>
+    >>> mock.return_value.foo.assert_called_with(a=2, b=3)
+
+From here it is a simple step to configure and then make assertions about
+chained calls. Of course another alternative is writing your code in a more
+testable way in the first place...
+
+So, suppose we have some code that looks a little bit like this:
+
+.. doctest::
+
+    >>> class Something(object):
+    ...     def __init__(self):
+    ...         self.backend = BackendProvider()
+    ...     def method(self):
+    ...         response = self.backend.get_endpoint('foobar').create_call('spam', 'eggs').start_call()
+    ...         # more code
+
+Assuming that `BackendProvider` is already well tested, how do we test
+`method()`? Specifically, we want to test that the code section `# more
+code` uses the response object in the correct way.
+
+As this chain of calls is made from an instance attribute we can monkey patch
+the `backend` attribute on a `Something` instance. In this particular case
+we are only interested in the return value from the final call to
+`start_call` so we don't have much configuration to do. Let's assume the
+object it returns is 'file-like', so we'll ensure that our response object
+uses the builtin `file` as its `spec`.
+
+To do this we create a mock instance as our mock backend and create a mock
+response object for it. To set the response as the return value for that final
+`start_call` we could do this:
+
+    `mock_backend.get_endpoint.return_value.create_call.return_value.start_call.return_value = mock_response`.
+
+We can do that in a slightly nicer way using the :meth:`~Mock.configure_mock`
+method to directly set the return value for us:
+
+.. doctest::
+
+    >>> something = Something()
+    >>> mock_response = Mock(spec=file)
+    >>> mock_backend = Mock()
+    >>> config = {'get_endpoint.return_value.create_call.return_value.start_call.return_value': mock_response}
+    >>> mock_backend.configure_mock(**config)
+
+With these we monkey patch the "mock backend" in place and can make the real
+call:
+
+.. doctest::
+
+    >>> something.backend = mock_backend
+    >>> something.method()
+
+Using :attr:`~Mock.mock_calls` we can check the chained call with a single
+assert. A chained call is several calls in one line of code, so there will be
+several entries in `mock_calls`. We can use :meth:`call.call_list` to create
+this list of calls for us:
+
+.. doctest::
+
+    >>> chained = call.get_endpoint('foobar').create_call('spam', 'eggs').start_call()
+    >>> call_list = chained.call_list()
+    >>> assert mock_backend.mock_calls == call_list
+
+
+Partial mocking
+===============
+
+In some tests I wanted to mock out a call to `datetime.date.today()
+<http://docs.python.org/library/datetime.html#datetime.date.today>`_ to return
+a known date, but I didn't want to prevent the code under test from
+creating new date objects. Unfortunately `datetime.date` is written in C, and
+so I couldn't just monkey-patch out the static `date.today` method.
+
+I found a simple way of doing this that involved effectively wrapping the date
+class with a mock, but passing through calls to the constructor to the real
+class (and returning real instances).
+
+The :func:`patch decorator <patch>` is used here to
+mock out the `date` class in the module under test. The :attr:`side_effect`
+attribute on the mock date class is then set to a lambda function that returns
+a real date. When the mock date class is called a real date will be
+constructed and returned by `side_effect`.
+
+.. doctest::
+
+    >>> from datetime import date
+    >>> with patch('mymodule.date') as mock_date:
+    ...     mock_date.today.return_value = date(2010, 10, 8)
+    ...     mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+    ...
+    ...     assert mymodule.date.today() == date(2010, 10, 8)
+    ...     assert mymodule.date(2009, 6, 8) == date(2009, 6, 8)
+    ...
+
+Note that we don't patch `datetime.date` globally, we patch `date` in the
+module that *uses* it. See :ref:`where to patch <where-to-patch>`.
+
+When `date.today()` is called a known date is returned, but calls to the
+`date(...)` constructor still return normal dates. Without this you can find
+yourself having to calculate an expected result using exactly the same
+algorithm as the code under test, which is a classic testing anti-pattern.
+
+Calls to the date constructor are recorded in the `mock_date` attributes
+(`call_count` and friends) which may also be useful for your tests.
+
+An alternative way of dealing with mocking dates, or other builtin classes,
+is discussed in `this blog entry
+<http://williamjohnbert.com/2011/07/how-to-unit-testing-in-django-with-mocking-and-patching/>`_.
+
+
+Mocking a Generator Method
+==========================
+
+A Python generator is a function or method that uses the `yield statement
+<http://docs.python.org/reference/simple_stmts.html#the-yield-statement>`_ to
+return a series of values when iterated over [#]_.
+
+A generator method / function is called to return the generator object. It is
+the generator object that is then iterated over. The protocol method for
+iteration is `__iter__
+<http://docs.python.org/library/stdtypes.html#container.__iter__>`_, so we can
+mock this using a `MagicMock`.
+
+Here's an example class with an "iter" method implemented as a generator:
+
+.. doctest::
+
+    >>> class Foo(object):
+    ...     def iter(self):
+    ...         for i in [1, 2, 3]:
+    ...             yield i
+    ...
+    >>> foo = Foo()
+    >>> list(foo.iter())
+    [1, 2, 3]
+
+
+How would we mock this class, and in particular its "iter" method?
+
+To configure the values returned from the iteration (implicit in the call to
+`list`), we need to configure the object returned by the call to `foo.iter()`.
+
+.. doctest::
+
+    >>> mock_foo = MagicMock()
+    >>> mock_foo.iter.return_value = iter([1, 2, 3])
+    >>> list(mock_foo.iter())
+    [1, 2, 3]
+
+.. [#] There are also generator expressions and more `advanced uses
+    <http://www.dabeaz.com/coroutines/index.html>`_ of generators, but we aren't
+    concerned about them here. A very good introduction to generators and how
+    powerful they are is: `Generator Tricks for Systems Programmers
+    <http://www.dabeaz.com/generators/>`_.
+
+
+Applying the same patch to every test method
+============================================
+
+If you want several patches in place for multiple test methods the obvious way
+is to apply the patch decorators to every method. This can feel like unnecessary
+repetition. For Python 2.6 or more recent you can use `patch` (in all its
+various forms) as a class decorator. This applies the patches to all test
+methods on the class. A test method is identified by methods whose names start
+with `test`:
+
+.. doctest::
+
+    >>> @patch('mymodule.SomeClass')
+    ... class MyTest(TestCase):
+    ...
+    ...     def test_one(self, MockSomeClass):
+    ...         self.assertTrue(mymodule.SomeClass is MockSomeClass)
+    ...
+    ...     def test_two(self, MockSomeClass):
+    ...         self.assertTrue(mymodule.SomeClass is MockSomeClass)
+    ...
+    ...     def not_a_test(self):
+    ...         return 'something'
+    ...
+    >>> MyTest('test_one').test_one()
+    >>> MyTest('test_two').test_two()
+    >>> MyTest('test_two').not_a_test()
+    'something'
+
+An alternative way of managing patches is to use the :ref:`start-and-stop`.
+These allow you to move the patching into your `setUp` and `tearDown` methods.
+
+.. doctest::
+
+    >>> class MyTest(TestCase):
+    ...     def setUp(self):
+    ...         self.patcher = patch('mymodule.foo')
+    ...         self.mock_foo = self.patcher.start()
+    ...
+    ...     def test_foo(self):
+    ...         self.assertTrue(mymodule.foo is self.mock_foo)
+    ...
+    ...     def tearDown(self):
+    ...         self.patcher.stop()
+    ...
+    >>> MyTest('test_foo').run()
+
+If you use this technique you must ensure that the patching is "undone" by
+calling `stop`. This can be fiddlier than you might think, because if an
+exception is raised in the setUp then tearDown is not called. `unittest2
+<http://pypi.python.org/pypi/unittest2>`_ cleanup functions make this simpler:
+
+
+.. doctest::
+
+    >>> class MyTest(TestCase):
+    ...     def setUp(self):
+    ...         patcher = patch('mymodule.foo')
+    ...         self.addCleanup(patcher.stop)
+    ...         self.mock_foo = patcher.start()
+    ...
+    ...     def test_foo(self):
+    ...         self.assertTrue(mymodule.foo is self.mock_foo)
+    ...
+    >>> MyTest('test_foo').run()
+
+
+Mocking Unbound Methods
+=======================
+
+Whilst writing tests today I needed to patch an *unbound method* (patching the
+method on the class rather than on the instance). I needed self to be passed
+in as the first argument because I want to make asserts about which objects
+were calling this particular method. The issue is that you can't patch with a
+mock for this, because if you replace an unbound method with a mock it doesn't
+become a bound method when fetched from the instance, and so it doesn't get
+self passed in. The workaround is to patch the unbound method with a real
+function instead. The :func:`patch` decorator makes it so simple to
+patch out methods with a mock that having to create a real function becomes a
+nuisance.
+
+If you pass `autospec=True` to patch then it does the patching with a
+*real* function object. This function object has the same signature as the one
+it is replacing, but delegates to a mock under the hood. You still get your
+mock auto-created in exactly the same way as before. What it means though, is
+that if you use it to patch out an unbound method on a class the mocked
+function will be turned into a bound method if it is fetched from an instance.
+It will have `self` passed in as the first argument, which is exactly what I
+wanted:
+
+.. doctest::
+
+    >>> class Foo(object):
+    ...   def foo(self):
+    ...     pass
+    ...
+    >>> with patch.object(Foo, 'foo', autospec=True) as mock_foo:
+    ...   mock_foo.return_value = 'foo'
+    ...   foo = Foo()
+    ...   foo.foo()
+    ...
+    'foo'
+    >>> mock_foo.assert_called_once_with(foo)
+
+If we don't use `autospec=True` then the unbound method is patched out
+with a Mock instance instead, and isn't called with `self`.
+
+
+Checking multiple calls with mock
+=================================
+
+mock has a nice API for making assertions about how your mock objects are used.
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> mock.foo_bar.return_value = None
+    >>> mock.foo_bar('baz', spam='eggs')
+    >>> mock.foo_bar.assert_called_with('baz', spam='eggs')
+
+If your mock is only being called once you can use the
+:meth:`assert_called_once_with` method that also asserts that the
+:attr:`call_count` is one.
+
+.. doctest::
+
+    >>> mock.foo_bar.assert_called_once_with('baz', spam='eggs')
+    >>> mock.foo_bar()
+    >>> mock.foo_bar.assert_called_once_with('baz', spam='eggs')
+    Traceback (most recent call last):
+        ...
+    AssertionError: Expected to be called once. Called 2 times.
+
+Both `assert_called_with` and `assert_called_once_with` make assertions about
+the *most recent* call. If your mock is going to be called several times, and
+you want to make assertions about *all* those calls you can use
+:attr:`~Mock.call_args_list`:
+
+.. doctest::
+
+    >>> mock = Mock(return_value=None)
+    >>> mock(1, 2, 3)
+    >>> mock(4, 5, 6)
+    >>> mock()
+    >>> mock.call_args_list
+    [call(1, 2, 3), call(4, 5, 6), call()]
+
+The :data:`call` helper makes it easy to make assertions about these calls. You
+can build up a list of expected calls and compare it to `call_args_list`. This
+looks remarkably similar to the repr of the `call_args_list`:
+
+.. doctest::
+
+    >>> expected = [call(1, 2, 3), call(4, 5, 6), call()]
+    >>> mock.call_args_list == expected
+    True
+
+
+Coping with mutable arguments
+=============================
+
+Another situation is rare, but can bite you, is when your mock is called with
+mutable arguments. `call_args` and `call_args_list` store *references* to the
+arguments. If the arguments are mutated by the code under test then you can no
+longer make assertions about what the values were when the mock was called.
+
+Here's some example code that shows the problem. Imagine the following functions
+defined in 'mymodule'::
+
+    def frob(val):
+        pass
+
+    def grob(val):
+        "First frob and then clear val"
+        frob(val)
+        val.clear()
+
+When we try to test that `grob` calls `frob` with the correct argument look
+what happens:
+
+.. doctest::
+
+    >>> with patch('mymodule.frob') as mock_frob:
+    ...     val = set([6])
+    ...     mymodule.grob(val)
+    ...
+    >>> val
+    set([])
+    >>> mock_frob.assert_called_with(set([6]))
+    Traceback (most recent call last):
+        ...
+    AssertionError: Expected: ((set([6]),), {})
+    Called with: ((set([]),), {})
+
+One possibility would be for mock to copy the arguments you pass in. This
+could then cause problems if you do assertions that rely on object identity
+for equality.
+
+Here's one solution that uses the :attr:`side_effect`
+functionality. If you provide a `side_effect` function for a mock then
+`side_effect` will be called with the same args as the mock. This gives us an
+opportunity to copy the arguments and store them for later assertions. In this
+example I'm using *another* mock to store the arguments so that I can use the
+mock methods for doing the assertion. Again a helper function sets this up for
+me.
+
+.. doctest::
+
+    >>> from copy import deepcopy
+    >>> from mock import Mock, patch, DEFAULT
+    >>> def copy_call_args(mock):
+    ...     new_mock = Mock()
+    ...     def side_effect(*args, **kwargs):
+    ...         args = deepcopy(args)
+    ...         kwargs = deepcopy(kwargs)
+    ...         new_mock(*args, **kwargs)
+    ...         return DEFAULT
+    ...     mock.side_effect = side_effect
+    ...     return new_mock
+    ...
+    >>> with patch('mymodule.frob') as mock_frob:
+    ...     new_mock = copy_call_args(mock_frob)
+    ...     val = set([6])
+    ...     mymodule.grob(val)
+    ...
+    >>> new_mock.assert_called_with(set([6]))
+    >>> new_mock.call_args
+    call(set([6]))
+
+`copy_call_args` is called with the mock that will be called. It returns a new
+mock that we do the assertion on. The `side_effect` function makes a copy of
+the args and calls our `new_mock` with the copy.
+
+.. note::
+
+    If your mock is only going to be used once there is an easier way of
+    checking arguments at the point they are called. You can simply do the
+    checking inside a `side_effect` function.
+
+    .. doctest::
+
+        >>> def side_effect(arg):
+        ...     assert arg == set([6])
+        ...
+        >>> mock = Mock(side_effect=side_effect)
+        >>> mock(set([6]))
+        >>> mock(set())
+        Traceback (most recent call last):
+            ...
+        AssertionError
+
+An alternative approach is to create a subclass of `Mock` or `MagicMock` that
+copies (using `copy.deepcopy
+<http://docs.python.org/library/copy.html#copy.deepcopy>`_) the arguments.
+Here's an example implementation:
+
+.. doctest::
+
+    >>> from copy import deepcopy
+    >>> class CopyingMock(MagicMock):
+    ...     def __call__(self, *args, **kwargs):
+    ...         args = deepcopy(args)
+    ...         kwargs = deepcopy(kwargs)
+    ...         return super(CopyingMock, self).__call__(*args, **kwargs)
+    ...
+    >>> c = CopyingMock(return_value=None)
+    >>> arg = set()
+    >>> c(arg)
+    >>> arg.add(1)
+    >>> c.assert_called_with(set())
+    >>> c.assert_called_with(arg)
+    Traceback (most recent call last):
+        ...
+    AssertionError: Expected call: mock(set([1]))
+    Actual call: mock(set([]))
+    >>> c.foo
+    <CopyingMock name='mock.foo' id='...'>
+
+When you subclass `Mock` or `MagicMock` all dynamically created attributes,
+and the `return_value` will use your subclass automatically. That means all
+children of a `CopyingMock` will also have the type `CopyingMock`.
+
+
+Raising exceptions on attribute access
+======================================
+
+You can use :class:`PropertyMock` to mimic the behaviour of properties. This
+includes raising exceptions when an attribute is accessed.
+
+Here's an example raising a `ValueError` when the 'foo' attribute is accessed:
+
+.. doctest::
+
+    >>> m = MagicMock()
+    >>> p = PropertyMock(side_effect=ValueError)
+    >>> type(m).foo = p
+    >>> m.foo
+    Traceback (most recent call last):
+    ....
+    ValueError
+
+Because every mock object has its own type, a new subclass of whichever mock
+class you're using, all mock objects are isolated from each other. You can
+safely attach properties (or other descriptors or whatever you want in fact)
+to `type(mock)` without affecting other mock objects.
+
+
+Multiple calls with different effects
+=====================================
+
+.. note::
+
+    In mock 1.0 the handling of iterable `side_effect` was changed. Any
+    exceptions in the iterable will be raised instead of returned.
+
+Handling code that needs to behave differently on subsequent calls during the
+test can be tricky. For example you may have a function that needs to raise
+an exception the first time it is called but returns a response on the second
+call (testing retry behaviour).
+
+One approach is to use a :attr:`side_effect` function that replaces itself. The
+first time it is called the `side_effect` sets a new `side_effect` that will
+be used for the second call. It then raises an exception:
+
+.. doctest::
+
+    >>> def side_effect(*args):
+    ...   def second_call(*args):
+    ...     return 'response'
+    ...   mock.side_effect = second_call
+    ...   raise Exception('boom')
+    ...
+    >>> mock = Mock(side_effect=side_effect)
+    >>> mock('first')
+    Traceback (most recent call last):
+        ...
+    Exception: boom
+    >>> mock('second')
+    'response'
+    >>> mock.assert_called_with('second')
+
+Another perfectly valid way would be to pop return values from a list. If the
+return value is an exception, raise it instead of returning it:
+
+.. doctest::
+
+    >>> returns = [Exception('boom'), 'response']
+    >>> def side_effect(*args):
+    ...   result = returns.pop(0)
+    ...   if isinstance(result, Exception):
+    ...     raise result
+    ...   return result
+    ...
+    >>> mock = Mock(side_effect=side_effect)
+    >>> mock('first')
+    Traceback (most recent call last):
+        ...
+    Exception: boom
+    >>> mock('second')
+    'response'
+    >>> mock.assert_called_with('second')
+
+Which approach you prefer is a matter of taste. The first approach is actually
+a line shorter but maybe the second approach is more readable.
+
+
+Nesting Patches
+===============
+
+Using patch as a context manager is nice, but if you do multiple patches you
+can end up with nested with statements indenting further and further to the
+right:
+
+.. doctest::
+
+    >>> class MyTest(TestCase):
+    ...
+    ...     def test_foo(self):
+    ...         with patch('mymodule.Foo') as mock_foo:
+    ...             with patch('mymodule.Bar') as mock_bar:
+    ...                 with patch('mymodule.Spam') as mock_spam:
+    ...                     assert mymodule.Foo is mock_foo
+    ...                     assert mymodule.Bar is mock_bar
+    ...                     assert mymodule.Spam is mock_spam
+    ...
+    >>> original = mymodule.Foo
+    >>> MyTest('test_foo').test_foo()
+    >>> assert mymodule.Foo is original
+
+With unittest2_ `cleanup` functions and the :ref:`start-and-stop` we can
+achieve the same effect without the nested indentation. A simple helper
+method, `create_patch`, puts the patch in place and returns the created mock
+for us:
+
+.. doctest::
+
+    >>> class MyTest(TestCase):
+    ...
+    ...     def create_patch(self, name):
+    ...         patcher = patch(name)
+    ...         thing = patcher.start()
+    ...         self.addCleanup(patcher.stop)
+    ...         return thing
+    ...
+    ...     def test_foo(self):
+    ...         mock_foo = self.create_patch('mymodule.Foo')
+    ...         mock_bar = self.create_patch('mymodule.Bar')
+    ...         mock_spam = self.create_patch('mymodule.Spam')
+    ...
+    ...         assert mymodule.Foo is mock_foo
+    ...         assert mymodule.Bar is mock_bar
+    ...         assert mymodule.Spam is mock_spam
+    ...
+    >>> original = mymodule.Foo
+    >>> MyTest('test_foo').run()
+    >>> assert mymodule.Foo is original
+
+
+Mocking a dictionary with MagicMock
+===================================
+
+You may want to mock a dictionary, or other container object, recording all
+access to it whilst having it still behave like a dictionary.
+
+We can do this with :class:`MagicMock`, which will behave like a dictionary,
+and using :data:`~Mock.side_effect` to delegate dictionary access to a real
+underlying dictionary that is under our control.
+
+When the `__getitem__` and `__setitem__` methods of our `MagicMock` are called
+(normal dictionary access) then `side_effect` is called with the key (and in
+the case of `__setitem__` the value too). We can also control what is returned.
+
+After the `MagicMock` has been used we can use attributes like
+:data:`~Mock.call_args_list` to assert about how the dictionary was used:
+
+.. doctest::
+
+    >>> my_dict = {'a': 1, 'b': 2, 'c': 3}
+    >>> def getitem(name):
+    ...      return my_dict[name]
+    ...
+    >>> def setitem(name, val):
+    ...     my_dict[name] = val
+    ...
+    >>> mock = MagicMock()
+    >>> mock.__getitem__.side_effect = getitem
+    >>> mock.__setitem__.side_effect = setitem
+
+.. note::
+
+    An alternative to using `MagicMock` is to use `Mock` and *only* provide
+    the magic methods you specifically want:
+
+    .. doctest::
+
+        >>> mock = Mock()
+        >>> mock.__setitem__ = Mock(side_effect=getitem)
+        >>> mock.__getitem__ = Mock(side_effect=setitem)
+
+    A *third* option is to use `MagicMock` but passing in `dict` as the `spec`
+    (or `spec_set`) argument so that the `MagicMock` created only has
+    dictionary magic methods available:
+
+    .. doctest::
+
+        >>> mock = MagicMock(spec_set=dict)
+        >>> mock.__getitem__.side_effect = getitem
+        >>> mock.__setitem__.side_effect = setitem
+
+With these side effect functions in place, the `mock` will behave like a normal
+dictionary but recording the access. It even raises a `KeyError` if you try
+to access a key that doesn't exist.
+
+.. doctest::
+
+    >>> mock['a']
+    1
+    >>> mock['c']
+    3
+    >>> mock['d']
+    Traceback (most recent call last):
+        ...
+    KeyError: 'd'
+    >>> mock['b'] = 'fish'
+    >>> mock['d'] = 'eggs'
+    >>> mock['b']
+    'fish'
+    >>> mock['d']
+    'eggs'
+
+After it has been used you can make assertions about the access using the normal
+mock methods and attributes:
+
+.. doctest::
+
+    >>> mock.__getitem__.call_args_list
+    [call('a'), call('c'), call('d'), call('b'), call('d')]
+    >>> mock.__setitem__.call_args_list
+    [call('b', 'fish'), call('d', 'eggs')]
+    >>> my_dict
+    {'a': 1, 'c': 3, 'b': 'fish', 'd': 'eggs'}
+
+
+Mock subclasses and their attributes
+====================================
+
+There are various reasons why you might want to subclass `Mock`. One reason
+might be to add helper methods. Here's a silly example:
+
+.. doctest::
+
+    >>> class MyMock(MagicMock):
+    ...     def has_been_called(self):
+    ...         return self.called
+    ...
+    >>> mymock = MyMock(return_value=None)
+    >>> mymock
+    <MyMock id='...'>
+    >>> mymock.has_been_called()
+    False
+    >>> mymock()
+    >>> mymock.has_been_called()
+    True
+
+The standard behaviour for `Mock` instances is that attributes and the return
+value mocks are of the same type as the mock they are accessed on. This ensures
+that `Mock` attributes are `Mocks` and `MagicMock` attributes are `MagicMocks`
+[#]_. So if you're subclassing to add helper methods then they'll also be
+available on the attributes and return value mock of instances of your
+subclass.
+
+.. doctest::
+
+    >>> mymock.foo
+    <MyMock name='mock.foo' id='...'>
+    >>> mymock.foo.has_been_called()
+    False
+    >>> mymock.foo()
+    <MyMock name='mock.foo()' id='...'>
+    >>> mymock.foo.has_been_called()
+    True
+
+Sometimes this is inconvenient. For example, `one user
+<https://code.google.com/p/mock/issues/detail?id=105>`_ is subclassing mock to
+created a `Twisted adaptor
+<http://twistedmatrix.com/documents/11.0.0/api/twisted.python.components.html>`_.
+Having this applied to attributes too actually causes errors.
+
+`Mock` (in all its flavours) uses a method called `_get_child_mock` to create
+these "sub-mocks" for attributes and return values. You can prevent your
+subclass being used for attributes by overriding this method. The signature is
+that it takes arbitrary keyword arguments (`**kwargs`) which are then passed
+onto the mock constructor:
+
+.. doctest::
+
+    >>> class Subclass(MagicMock):
+    ...     def _get_child_mock(self, **kwargs):
+    ...         return MagicMock(**kwargs)
+    ...
+    >>> mymock = Subclass()
+    >>> mymock.foo
+    <MagicMock name='mock.foo' id='...'>
+    >>> assert isinstance(mymock, Subclass)
+    >>> assert not isinstance(mymock.foo, Subclass)
+    >>> assert not isinstance(mymock(), Subclass)
+
+.. [#] An exception to this rule are the non-callable mocks. Attributes use the
+    callable variant because otherwise non-callable mocks couldn't have callable
+    methods.
+
+
+Mocking imports with patch.dict
+===============================
+
+One situation where mocking can be hard is where you have a local import inside
+a function. These are harder to mock because they aren't using an object from
+the module namespace that we can patch out.
+
+Generally local imports are to be avoided. They are sometimes done to prevent
+circular dependencies, for which there is *usually* a much better way to solve
+the problem (refactor the code) or to prevent "up front costs" by delaying the
+import. This can also be solved in better ways than an unconditional local
+import (store the module as a class or module attribute and only do the import
+on first use).
+
+That aside there is a way to use `mock` to affect the results of an import.
+Importing fetches an *object* from the `sys.modules` dictionary. Note that it
+fetches an *object*, which need not be a module. Importing a module for the
+first time results in a module object being put in `sys.modules`, so usually
+when you import something you get a module back. This need not be the case
+however.
+
+This means you can use :func:`patch.dict` to *temporarily* put a mock in place
+in `sys.modules`. Any imports whilst this patch is active will fetch the mock.
+When the patch is complete (the decorated function exits, the with statement
+body is complete or `patcher.stop()` is called) then whatever was there
+previously will be restored safely.
+
+Here's an example that mocks out the 'fooble' module.
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> with patch.dict('sys.modules', {'fooble': mock}):
+    ...    import fooble
+    ...    fooble.blob()
+    ...
+    <Mock name='mock.blob()' id='...'>
+    >>> assert 'fooble' not in sys.modules
+    >>> mock.blob.assert_called_once_with()
+
+As you can see the `import fooble` succeeds, but on exit there is no 'fooble'
+left in `sys.modules`.
+
+This also works for the `from module import name` form:
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> with patch.dict('sys.modules', {'fooble': mock}):
+    ...    from fooble import blob
+    ...    blob.blip()
+    ...
+    <Mock name='mock.blob.blip()' id='...'>
+    >>> mock.blob.blip.assert_called_once_with()
+
+With slightly more work you can also mock package imports:
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> modules = {'package': mock, 'package.module': mock.module}
+    >>> with patch.dict('sys.modules', modules):
+    ...    from package.module import fooble
+    ...    fooble()
+    ...
+    <Mock name='mock.module.fooble()' id='...'>
+    >>> mock.module.fooble.assert_called_once_with()
+
+
+Tracking order of calls and less verbose call assertions
+========================================================
+
+The :class:`Mock` class allows you to track the *order* of method calls on
+your mock objects through the :attr:`~Mock.method_calls` attribute. This
+doesn't allow you to track the order of calls between separate mock objects,
+however we can use :attr:`~Mock.mock_calls` to achieve the same effect.
+
+Because mocks track calls to child mocks in `mock_calls`, and accessing an
+arbitrary attribute of a mock creates a child mock, we can create our separate
+mocks from a parent one. Calls to those child mock will then all be recorded,
+in order, in the `mock_calls` of the parent:
+
+.. doctest::
+
+    >>> manager = Mock()
+    >>> mock_foo = manager.foo
+    >>> mock_bar = manager.bar
+
+    >>> mock_foo.something()
+    <Mock name='mock.foo.something()' id='...'>
+    >>> mock_bar.other.thing()
+    <Mock name='mock.bar.other.thing()' id='...'>
+
+    >>> manager.mock_calls
+    [call.foo.something(), call.bar.other.thing()]
+
+We can then assert about the calls, including the order, by comparing with
+the `mock_calls` attribute on the manager mock:
+
+.. doctest::
+
+    >>> expected_calls = [call.foo.something(), call.bar.other.thing()]
+    >>> manager.mock_calls == expected_calls
+    True
+
+If `patch` is creating, and putting in place, your mocks then you can attach
+them to a manager mock using the :meth:`~Mock.attach_mock` method. After
+attaching calls will be recorded in `mock_calls` of the manager.
+
+.. doctest::
+
+    >>> manager = MagicMock()
+    >>> with patch('mymodule.Class1') as MockClass1:
+    ...     with patch('mymodule.Class2') as MockClass2:
+    ...         manager.attach_mock(MockClass1, 'MockClass1')
+    ...         manager.attach_mock(MockClass2, 'MockClass2')
+    ...         MockClass1().foo()
+    ...         MockClass2().bar()
+    ...
+    <MagicMock name='mock.MockClass1().foo()' id='...'>
+    <MagicMock name='mock.MockClass2().bar()' id='...'>
+    >>> manager.mock_calls
+    [call.MockClass1(),
+     call.MockClass1().foo(),
+     call.MockClass2(),
+     call.MockClass2().bar()]
+
+If many calls have been made, but you're only interested in a particular
+sequence of them then an alternative is to use the
+:meth:`~Mock.assert_has_calls` method. This takes a list of calls (constructed
+with the :data:`call` object). If that sequence of calls are in
+:attr:`~Mock.mock_calls` then the assert succeeds.
+
+.. doctest::
+
+    >>> m = MagicMock()
+    >>> m().foo().bar().baz()
+    <MagicMock name='mock().foo().bar().baz()' id='...'>
+    >>> m.one().two().three()
+    <MagicMock name='mock.one().two().three()' id='...'>
+    >>> calls = call.one().two().three().call_list()
+    >>> m.assert_has_calls(calls)
+
+Even though the chained call `m.one().two().three()` aren't the only calls that
+have been made to the mock, the assert still succeeds.
+
+Sometimes a mock may have several calls made to it, and you are only interested
+in asserting about *some* of those calls. You may not even care about the
+order. In this case you can pass `any_order=True` to `assert_has_calls`:
+
+.. doctest::
+
+    >>> m = MagicMock()
+    >>> m(1), m.two(2, 3), m.seven(7), m.fifty('50')
+    (...)
+    >>> calls = [call.fifty('50'), call(1), call.seven(7)]
+    >>> m.assert_has_calls(calls, any_order=True)
+
+
+More complex argument matching
+==============================
+
+Using the same basic concept as `ANY` we can implement matchers to do more
+complex assertions on objects used as arguments to mocks.
+
+Suppose we expect some object to be passed to a mock that by default
+compares equal based on object identity (which is the Python default for user
+defined classes). To use :meth:`~Mock.assert_called_with` we would need to pass
+in the exact same object. If we are only interested in some of the attributes
+of this object then we can create a matcher that will check these attributes
+for us.
+
+You can see in this example how a 'standard' call to `assert_called_with` isn't
+sufficient:
+
+.. doctest::
+
+    >>> class Foo(object):
+    ...     def __init__(self, a, b):
+    ...         self.a, self.b = a, b
+    ...
+    >>> mock = Mock(return_value=None)
+    >>> mock(Foo(1, 2))
+    >>> mock.assert_called_with(Foo(1, 2))
+    Traceback (most recent call last):
+        ...
+    AssertionError: Expected: call(<__main__.Foo object at 0x...>)
+    Actual call: call(<__main__.Foo object at 0x...>)
+
+A comparison function for our `Foo` class might look something like this:
+
+.. doctest::
+
+    >>> def compare(self, other):
+    ...     if not type(self) == type(other):
+    ...         return False
+    ...     if self.a != other.a:
+    ...         return False
+    ...     if self.b != other.b:
+    ...         return False
+    ...     return True
+    ...
+
+And a matcher object that can use comparison functions like this for its
+equality operation would look something like this:
+
+.. doctest::
+
+    >>> class Matcher(object):
+    ...     def __init__(self, compare, some_obj):
+    ...         self.compare = compare
+    ...         self.some_obj = some_obj
+    ...     def __eq__(self, other):
+    ...         return self.compare(self.some_obj, other)
+    ...
+
+Putting all this together:
+
+.. doctest::
+
+    >>> match_foo = Matcher(compare, Foo(1, 2))
+    >>> mock.assert_called_with(match_foo)
+
+The `Matcher` is instantiated with our compare function and the `Foo` object
+we want to compare against. In `assert_called_with` the `Matcher` equality
+method will be called, which compares the object the mock was called with
+against the one we created our matcher with. If they match then
+`assert_called_with` passes, and if they don't an `AssertionError` is raised:
+
+.. doctest::
+
+    >>> match_wrong = Matcher(compare, Foo(3, 4))
+    >>> mock.assert_called_with(match_wrong)
+    Traceback (most recent call last):
+        ...
+    AssertionError: Expected: ((<Matcher object at 0x...>,), {})
+    Called with: ((<Foo object at 0x...>,), {})
+
+With a bit of tweaking you could have the comparison function raise the
+`AssertionError` directly and provide a more useful failure message.
+
+As of version 1.5, the Python testing library `PyHamcrest
+<http://pypi.python.org/pypi/PyHamcrest>`_ provides similar functionality,
+that may be useful here, in the form of its equality matcher
+(`hamcrest.library.integration.match_equality
+<http://packages.python.org/PyHamcrest/integration.html#hamcrest.library.integration.match_equality>`_).
+
+
+Less verbose configuration of mock objects
+==========================================
+
+This recipe, for easier configuration of mock objects, is now part of `Mock`.
+See the :meth:`~Mock.configure_mock` method.
+
+
+Matching any argument in assertions
+===================================
+
+This example is now built in to mock. See :data:`ANY`.
+
+
+Mocking Properties
+==================
+
+This example is now built in to mock. See :class:`PropertyMock`.
+
+
+Mocking open
+============
+
+This example is now built in to mock. See :func:`mock_open`.
+
+
+Mocks without some attributes
+=============================
+
+This example is now built in to mock. See :ref:`deleting-attributes`.

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/getting-started.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/getting-started.txt
@@ -1,0 +1,479 @@
+===========================
+ Getting Started with Mock
+===========================
+
+.. _getting-started:
+
+.. index:: Getting Started
+
+.. testsetup::
+
+    class SomeClass(object):
+        static_method = None
+        class_method = None
+        attribute = None
+
+    sys.modules['package'] = package = Mock(name='package')
+    sys.modules['package.module'] = module = package.module
+    sys.modules['module'] = package.module
+
+
+Using Mock
+==========
+
+Mock Patching Methods
+---------------------
+
+Common uses for :class:`Mock` objects include:
+
+* Patching methods
+* Recording method calls on objects
+
+You might want to replace a method on an object to check that
+it is called with the correct arguments by another part of the system:
+
+.. doctest::
+
+    >>> real = SomeClass()
+    >>> real.method = MagicMock(name='method')
+    >>> real.method(3, 4, 5, key='value')
+    <MagicMock name='method()' id='...'>
+
+Once our mock has been used (`real.method` in this example) it has methods
+and attributes that allow you to make assertions about how it has been used.
+
+.. note::
+
+    In most of these examples the :class:`Mock` and :class:`MagicMock` classes
+    are interchangeable. As the `MagicMock` is the more capable class it makes
+    a sensible one to use by default.
+
+Once the mock has been called its :attr:`~Mock.called` attribute is set to
+`True`. More importantly we can use the :meth:`~Mock.assert_called_with` or
+:meth:`~Mock.assert_called_once_with` method to check that it was called with
+the correct arguments.
+
+This example tests that calling `ProductionClass().method` results in a call to
+the `something` method:
+
+.. doctest::
+
+    >>> from mock import MagicMock
+    >>> class ProductionClass(object):
+    ...     def method(self):
+    ...         self.something(1, 2, 3)
+    ...     def something(self, a, b, c):
+    ...         pass
+    ...
+    >>> real = ProductionClass()
+    >>> real.something = MagicMock()
+    >>> real.method()
+    >>> real.something.assert_called_once_with(1, 2, 3)
+
+
+
+Mock for Method Calls on an Object
+----------------------------------
+
+In the last example we patched a method directly on an object to check that it
+was called correctly. Another common use case is to pass an object into a
+method (or some part of the system under test) and then check that it is used
+in the correct way.
+
+The simple `ProductionClass` below has a `closer` method. If it is called with
+an object then it calls `close` on it.
+
+.. doctest::
+
+    >>> class ProductionClass(object):
+    ...     def closer(self, something):
+    ...         something.close()
+    ...
+
+So to test it we need to pass in an object with a `close` method and check
+that it was called correctly.
+
+.. doctest::
+
+    >>> real = ProductionClass()
+    >>> mock = Mock()
+    >>> real.closer(mock)
+    >>> mock.close.assert_called_with()
+
+We don't have to do any work to provide the 'close' method on our mock.
+Accessing close creates it. So, if 'close' hasn't already been called then
+accessing it in the test will create it, but :meth:`~Mock.assert_called_with`
+will raise a failure exception.
+
+
+Mocking Classes
+---------------
+
+A common use case is to mock out classes instantiated by your code under test.
+When you patch a class, then that class is replaced with a mock. Instances
+are created by *calling the class*. This means you access the "mock instance"
+by looking at the return value of the mocked class.
+
+In the example below we have a function `some_function` that instantiates `Foo`
+and calls a method on it. The call to `patch` replaces the class `Foo` with a
+mock. The `Foo` instance is the result of calling the mock, so it is configured
+by modifying the mock :attr:`~Mock.return_value`.
+
+.. doctest::
+
+    >>> def some_function():
+    ...     instance = module.Foo()
+    ...     return instance.method()
+    ...
+    >>> with patch('module.Foo') as mock:
+    ...     instance = mock.return_value
+    ...     instance.method.return_value = 'the result'
+    ...     result = some_function()
+    ...     assert result == 'the result'
+
+
+Naming your mocks
+-----------------
+
+It can be useful to give your mocks a name. The name is shown in the repr of
+the mock and can be helpful when the mock appears in test failure messages. The
+name is also propagated to attributes or methods of the mock:
+
+.. doctest::
+
+    >>> mock = MagicMock(name='foo')
+    >>> mock
+    <MagicMock name='foo' id='...'>
+    >>> mock.method
+    <MagicMock name='foo.method' id='...'>
+
+
+Tracking all Calls
+------------------
+
+Often you want to track more than a single call to a method. The
+:attr:`~Mock.mock_calls` attribute records all calls
+to child attributes of the mock - and also to their children.
+
+.. doctest::
+
+    >>> mock = MagicMock()
+    >>> mock.method()
+    <MagicMock name='mock.method()' id='...'>
+    >>> mock.attribute.method(10, x=53)
+    <MagicMock name='mock.attribute.method()' id='...'>
+    >>> mock.mock_calls
+    [call.method(), call.attribute.method(10, x=53)]
+
+If you make an assertion about `mock_calls` and any unexpected methods
+have been called, then the assertion will fail. This is useful because as well
+as asserting that the calls you expected have been made, you are also checking
+that they were made in the right order and with no additional calls:
+
+You use the :data:`call` object to construct lists for comparing with
+`mock_calls`:
+
+.. doctest::
+
+    >>> expected = [call.method(), call.attribute.method(10, x=53)]
+    >>> mock.mock_calls == expected
+    True
+
+
+Setting Return Values and Attributes
+------------------------------------
+
+Setting the return values on a mock object is trivially easy:
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> mock.return_value = 3
+    >>> mock()
+    3
+
+Of course you can do the same for methods on the mock:
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> mock.method.return_value = 3
+    >>> mock.method()
+    3
+
+The return value can also be set in the constructor:
+
+.. doctest::
+
+    >>> mock = Mock(return_value=3)
+    >>> mock()
+    3
+
+If you need an attribute setting on your mock, just do it:
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> mock.x = 3
+    >>> mock.x
+    3
+
+Sometimes you want to mock up a more complex situation, like for example
+`mock.connection.cursor().execute("SELECT 1")`. If we wanted this call to
+return a list, then we have to configure the result of the nested call.
+
+We can use :data:`call` to construct the set of calls in a "chained call" like
+this for easy assertion afterwards:
+
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> cursor = mock.connection.cursor.return_value
+    >>> cursor.execute.return_value = ['foo']
+    >>> mock.connection.cursor().execute("SELECT 1")
+    ['foo']
+    >>> expected = call.connection.cursor().execute("SELECT 1").call_list()
+    >>> mock.mock_calls
+    [call.connection.cursor(), call.connection.cursor().execute('SELECT 1')]
+    >>> mock.mock_calls == expected
+    True
+
+It is the call to `.call_list()` that turns our call object into a list of
+calls representing the chained calls.
+
+
+
+Raising exceptions with mocks
+-----------------------------
+
+A useful attribute is :attr:`~Mock.side_effect`. If you set this to an
+exception class or instance then the exception will be raised when the mock
+is called.
+
+.. doctest::
+
+    >>> mock = Mock(side_effect=Exception('Boom!'))
+    >>> mock()
+    Traceback (most recent call last):
+      ...
+    Exception: Boom!
+
+
+Side effect functions and iterables
+-----------------------------------
+
+`side_effect` can also be set to a function or an iterable. The use case for
+`side_effect` as an iterable is where your mock is going to be called several
+times, and you want each call to return a different value. When you set
+`side_effect` to an iterable every call to the mock returns the next value
+from the iterable:
+
+.. doctest::
+
+    >>> mock = MagicMock(side_effect=[4, 5, 6])
+    >>> mock()
+    4
+    >>> mock()
+    5
+    >>> mock()
+    6
+
+
+For more advanced use cases, like dynamically varying the return values
+depending on what the mock is called with, `side_effect` can be a function.
+The function will be called with the same arguments as the mock. Whatever the
+function returns is what the call returns:
+
+.. doctest::
+
+    >>> vals = {(1, 2): 1, (2, 3): 2}
+    >>> def side_effect(*args):
+    ...     return vals[args]
+    ...
+    >>> mock = MagicMock(side_effect=side_effect)
+    >>> mock(1, 2)
+    1
+    >>> mock(2, 3)
+    2
+
+
+Creating a Mock from an Existing Object
+---------------------------------------
+
+One problem with over use of mocking is that it couples your tests to the
+implementation of your mocks rather than your real code. Suppose you have a
+class that implements `some_method`. In a test for another class, you
+provide a mock of this object that *also* provides `some_method`. If later
+you refactor the first class, so that it no longer has `some_method` - then
+your tests will continue to pass even though your code is now broken!
+
+`Mock` allows you to provide an object as a specification for the mock,
+using the `spec` keyword argument. Accessing methods / attributes on the
+mock that don't exist on your specification object will immediately raise an
+attribute error. If you change the implementation of your specification, then
+tests that use that class will start failing immediately without you having to
+instantiate the class in those tests.
+
+.. doctest::
+
+    >>> mock = Mock(spec=SomeClass)
+    >>> mock.old_method()
+    Traceback (most recent call last):
+       ...
+    AttributeError: object has no attribute 'old_method'
+
+If you want a stronger form of specification that prevents the setting
+of arbitrary attributes as well as the getting of them then you can use
+`spec_set` instead of `spec`.
+
+
+
+Patch Decorators
+================
+
+.. note::
+
+   With `patch` it matters that you patch objects in the namespace where they
+   are looked up. This is normally straightforward, but for a quick guide
+   read :ref:`where to patch <where-to-patch>`.
+
+
+A common need in tests is to patch a class attribute or a module attribute,
+for example patching a builtin or patching a class in a module to test that it
+is instantiated. Modules and classes are effectively global, so patching on
+them has to be undone after the test or the patch will persist into other
+tests and cause hard to diagnose problems.
+
+mock provides three convenient decorators for this: `patch`, `patch.object` and
+`patch.dict`. `patch` takes a single string, of the form
+`package.module.Class.attribute` to specify the attribute you are patching. It
+also optionally takes a value that you want the attribute (or class or
+whatever) to be replaced with. 'patch.object' takes an object and the name of
+the attribute you would like patched, plus optionally the value to patch it
+with.
+
+`patch.object`:
+
+.. doctest::
+
+    >>> original = SomeClass.attribute
+    >>> @patch.object(SomeClass, 'attribute', sentinel.attribute)
+    ... def test():
+    ...     assert SomeClass.attribute == sentinel.attribute
+    ...
+    >>> test()
+    >>> assert SomeClass.attribute == original
+
+    >>> @patch('package.module.attribute', sentinel.attribute)
+    ... def test():
+    ...     from package.module import attribute
+    ...     assert attribute is sentinel.attribute
+    ...
+    >>> test()
+
+If you are patching a module (including `__builtin__`) then use `patch`
+instead of `patch.object`:
+
+.. doctest::
+
+    >>> mock = MagicMock(return_value = sentinel.file_handle)
+    >>> with patch('__builtin__.open', mock):
+    ...     handle = open('filename', 'r')
+    ...
+    >>> mock.assert_called_with('filename', 'r')
+    >>> assert handle == sentinel.file_handle, "incorrect file handle returned"
+
+The module name can be 'dotted', in the form `package.module` if needed:
+
+.. doctest::
+
+    >>> @patch('package.module.ClassName.attribute', sentinel.attribute)
+    ... def test():
+    ...     from package.module import ClassName
+    ...     assert ClassName.attribute == sentinel.attribute
+    ...
+    >>> test()
+
+A nice pattern is to actually decorate test methods themselves:
+
+.. doctest::
+
+    >>> class MyTest(unittest2.TestCase):
+    ...     @patch.object(SomeClass, 'attribute', sentinel.attribute)
+    ...     def test_something(self):
+    ...         self.assertEqual(SomeClass.attribute, sentinel.attribute)
+    ...
+    >>> original = SomeClass.attribute
+    >>> MyTest('test_something').test_something()
+    >>> assert SomeClass.attribute == original
+
+If you want to patch with a Mock, you can use `patch` with only one argument
+(or `patch.object` with two arguments). The mock will be created for you and
+passed into the test function / method:
+
+.. doctest::
+
+    >>> class MyTest(unittest2.TestCase):
+    ...     @patch.object(SomeClass, 'static_method')
+    ...     def test_something(self, mock_method):
+    ...         SomeClass.static_method()
+    ...         mock_method.assert_called_with()
+    ...
+    >>> MyTest('test_something').test_something()
+
+You can stack up multiple patch decorators using this pattern:
+
+.. doctest::
+
+    >>> class MyTest(unittest2.TestCase):
+    ...     @patch('package.module.ClassName1')
+    ...     @patch('package.module.ClassName2')
+    ...     def test_something(self, MockClass2, MockClass1):
+    ...         self.assertTrue(package.module.ClassName1 is MockClass1)
+    ...         self.assertTrue(package.module.ClassName2 is MockClass2)
+    ...
+    >>> MyTest('test_something').test_something()
+
+When you nest patch decorators the mocks are passed in to the decorated
+function in the same order they applied (the normal *python* order that
+decorators are applied). This means from the bottom up, so in the example
+above the mock for `test_module.ClassName2` is passed in first.
+
+There is also :func:`patch.dict` for setting values in a dictionary just
+during a scope and restoring the dictionary to its original state when the test
+ends:
+
+.. doctest::
+
+   >>> foo = {'key': 'value'}
+   >>> original = foo.copy()
+   >>> with patch.dict(foo, {'newkey': 'newvalue'}, clear=True):
+   ...     assert foo == {'newkey': 'newvalue'}
+   ...
+   >>> assert foo == original
+
+`patch`, `patch.object` and `patch.dict` can all be used as context managers.
+
+Where you use `patch` to create a mock for you, you can get a reference to the
+mock using the "as" form of the with statement:
+
+.. doctest::
+
+    >>> class ProductionClass(object):
+    ...     def method(self):
+    ...         pass
+    ...
+    >>> with patch.object(ProductionClass, 'method') as mock_method:
+    ...     mock_method.return_value = None
+    ...     real = ProductionClass()
+    ...     real.method(1, 2, 3)
+    ...
+    >>> mock_method.assert_called_with(1, 2, 3)
+
+
+As an alternative `patch`, `patch.object` and `patch.dict` can be used as
+class decorators. When used in this way it is the same as applying the
+decorator indvidually to every method whose name starts with "test".
+
+For some more advanced examples, see the :ref:`further-examples` page.

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/helpers.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/helpers.txt
@@ -1,0 +1,583 @@
+=========
+ Helpers
+=========
+
+.. currentmodule:: mock
+
+.. testsetup::
+
+    mock.FILTER_DIR = True
+    from pprint import pprint as pp
+    original_dir = dir
+    def dir(obj):
+        print pp(original_dir(obj))
+
+    import urllib2
+    __main__.urllib2 = urllib2
+
+.. testcleanup::
+
+    dir = original_dir
+    mock.FILTER_DIR = True
+
+
+
+call
+====
+
+.. function:: call(*args, **kwargs)
+
+    `call` is a helper object for making simpler assertions, for comparing
+    with :attr:`~Mock.call_args`, :attr:`~Mock.call_args_list`,
+    :attr:`~Mock.mock_calls` and :attr: `~Mock.method_calls`. `call` can also be
+    used with :meth:`~Mock.assert_has_calls`.
+
+    .. doctest::
+
+        >>> m = MagicMock(return_value=None)
+        >>> m(1, 2, a='foo', b='bar')
+        >>> m()
+        >>> m.call_args_list == [call(1, 2, a='foo', b='bar'), call()]
+        True
+
+.. method:: call.call_list()
+
+    For a call object that represents multiple calls, `call_list`
+    returns a list of all the intermediate calls as well as the
+    final call.
+
+`call_list` is particularly useful for making assertions on "chained calls". A
+chained call is multiple calls on a single line of code. This results in
+multiple entries in :attr:`~Mock.mock_calls` on a mock. Manually constructing
+the sequence of calls can be tedious.
+
+:meth:`~call.call_list` can construct the sequence of calls from the same
+chained call:
+
+.. doctest::
+
+    >>> m = MagicMock()
+    >>> m(1).method(arg='foo').other('bar')(2.0)
+    <MagicMock name='mock().method().other()()' id='...'>
+    >>> kall = call(1).method(arg='foo').other('bar')(2.0)
+    >>> kall.call_list()
+    [call(1),
+     call().method(arg='foo'),
+     call().method().other('bar'),
+     call().method().other()(2.0)]
+    >>> m.mock_calls == kall.call_list()
+    True
+
+.. _calls-as-tuples:
+
+A `call` object is either a tuple of (positional args, keyword args) or
+(name, positional args, keyword args) depending on how it was constructed. When
+you construct them yourself this isn't particularly interesting, but the `call`
+objects that are in the :attr:`Mock.call_args`, :attr:`Mock.call_args_list` and
+:attr:`Mock.mock_calls` attributes can be introspected to get at the individual
+arguments they contain.
+
+The `call` objects in :attr:`Mock.call_args` and :attr:`Mock.call_args_list`
+are two-tuples of (positional args, keyword args) whereas the `call` objects
+in :attr:`Mock.mock_calls`, along with ones you construct yourself, are
+three-tuples of (name, positional args, keyword args).
+
+You can use their "tupleness" to pull out the individual arguments for more
+complex introspection and assertions. The positional arguments are a tuple
+(an empty tuple if there are no positional arguments) and the keyword
+arguments are a dictionary:
+
+.. doctest::
+
+    >>> m = MagicMock(return_value=None)
+    >>> m(1, 2, 3, arg='one', arg2='two')
+    >>> kall = m.call_args
+    >>> args, kwargs = kall
+    >>> args
+    (1, 2, 3)
+    >>> kwargs
+    {'arg2': 'two', 'arg': 'one'}
+    >>> args is kall[0]
+    True
+    >>> kwargs is kall[1]
+    True
+
+    >>> m = MagicMock()
+    >>> m.foo(4, 5, 6, arg='two', arg2='three')
+    <MagicMock name='mock.foo()' id='...'>
+    >>> kall = m.mock_calls[0]
+    >>> name, args, kwargs = kall
+    >>> name
+    'foo'
+    >>> args
+    (4, 5, 6)
+    >>> kwargs
+    {'arg2': 'three', 'arg': 'two'}
+    >>> name is m.mock_calls[0][0]
+    True
+
+
+create_autospec
+===============
+
+.. function:: create_autospec(spec, spec_set=False, instance=False, **kwargs)
+
+    Create a mock object using another object as a spec. Attributes on the
+    mock will use the corresponding attribute on the `spec` object as their
+    spec.
+
+    Functions or methods being mocked will have their arguments checked to
+    ensure that they are called with the correct signature.
+
+    If `spec_set` is `True` then attempting to set attributes that don't exist
+    on the spec object will raise an `AttributeError`.
+
+    If a class is used as a spec then the return value of the mock (the
+    instance of the class) will have the same spec. You can use a class as the
+    spec for an instance object by passing `instance=True`. The returned mock
+    will only be callable if instances of the mock are callable.
+
+    `create_autospec` also takes arbitrary keyword arguments that are passed to
+    the constructor of the created mock.
+
+See :ref:`auto-speccing` for examples of how to use auto-speccing with
+`create_autospec` and the `autospec` argument to :func:`patch`.
+
+
+ANY
+===
+
+.. data:: ANY
+
+Sometimes you may need to make assertions about *some* of the arguments in a
+call to mock, but either not care about some of the arguments or want to pull
+them individually out of :attr:`~Mock.call_args` and make more complex
+assertions on them.
+
+To ignore certain arguments you can pass in objects that compare equal to
+*everything*. Calls to :meth:`~Mock.assert_called_with` and
+:meth:`~Mock.assert_called_once_with` will then succeed no matter what was
+passed in.
+
+.. doctest::
+
+    >>> mock = Mock(return_value=None)
+    >>> mock('foo', bar=object())
+    >>> mock.assert_called_once_with('foo', bar=ANY)
+
+`ANY` can also be used in comparisons with call lists like
+:attr:`~Mock.mock_calls`:
+
+.. doctest::
+
+    >>> m = MagicMock(return_value=None)
+    >>> m(1)
+    >>> m(1, 2)
+    >>> m(object())
+    >>> m.mock_calls == [call(1), call(1, 2), ANY]
+    True
+
+
+
+FILTER_DIR
+==========
+
+.. data:: FILTER_DIR
+
+`FILTER_DIR` is a module level variable that controls the way mock objects
+respond to `dir` (only for Python 2.6 or more recent). The default is `True`,
+which uses the filtering described below, to only show useful members. If you
+dislike this filtering, or need to switch it off for diagnostic purposes, then
+set `mock.FILTER_DIR = False`.
+
+With filtering on, `dir(some_mock)` shows only useful attributes and will
+include any dynamically created attributes that wouldn't normally be shown.
+If the mock was created with a `spec` (or `autospec` of course) then all the
+attributes from the original are shown, even if they haven't been accessed
+yet:
+
+.. doctest::
+
+    >>> dir(Mock())
+    ['assert_any_call',
+     'assert_called_once_with',
+     'assert_called_with',
+     'assert_has_calls',
+     'attach_mock',
+     ...
+    >>> import urllib2
+    >>> dir(Mock(spec=urllib2))
+    ['AbstractBasicAuthHandler',
+     'AbstractDigestAuthHandler',
+     'AbstractHTTPHandler',
+     'BaseHandler',
+     ...
+
+Many of the not-very-useful (private to `Mock` rather than the thing being
+mocked) underscore and double underscore prefixed attributes have been
+filtered from the result of calling `dir` on a `Mock`. If you dislike this
+behaviour you can switch it off by setting the module level switch
+`FILTER_DIR`:
+
+.. doctest::
+
+    >>> import mock
+    >>> mock.FILTER_DIR = False
+    >>> dir(mock.Mock())
+    ['_NonCallableMock__get_return_value',
+     '_NonCallableMock__get_side_effect',
+     '_NonCallableMock__return_value_doc',
+     '_NonCallableMock__set_return_value',
+     '_NonCallableMock__set_side_effect',
+     '__call__',
+     '__class__',
+     ...
+
+Alternatively you can just use `vars(my_mock)` (instance members) and
+`dir(type(my_mock))` (type members) to bypass the filtering irrespective of
+`mock.FILTER_DIR`.
+
+
+mock_open
+=========
+
+.. function:: mock_open(mock=None, read_data=None)
+
+    A helper function to create a mock to replace the use of `open`. It works
+    for `open` called directly or used as a context manager.
+
+    The `mock` argument is the mock object to configure. If `None` (the
+    default) then a `MagicMock` will be created for you, with the API limited
+    to methods or attributes available on standard file handles.
+
+    `read_data` is a string for the `read` method of the file handle to return.
+    This is an empty string by default.
+
+Using `open` as a context manager is a great way to ensure your file handles
+are closed properly and is becoming common::
+
+    with open('/some/path', 'w') as f:
+        f.write('something')
+
+The issue is that even if you mock out the call to `open` it is the
+*returned object* that is used as a context manager (and has `__enter__` and
+`__exit__` called).
+
+Mocking context managers with a :class:`MagicMock` is common enough and fiddly
+enough that a helper function is useful.
+
+.. doctest::
+
+    >>> from mock import mock_open
+    >>> m = mock_open()
+    >>> with patch('__main__.open', m, create=True):
+    ...     with open('foo', 'w') as h:
+    ...         h.write('some stuff')
+    ...
+    >>> m.mock_calls
+    [call('foo', 'w'),
+     call().__enter__(),
+     call().write('some stuff'),
+     call().__exit__(None, None, None)]
+    >>> m.assert_called_once_with('foo', 'w')
+    >>> handle = m()
+    >>> handle.write.assert_called_once_with('some stuff')
+
+And for reading files:
+
+.. doctest::
+
+    >>> with patch('__main__.open', mock_open(read_data='bibble'), create=True) as m:
+    ...     with open('foo') as h:
+    ...         result = h.read()
+    ...
+    >>> m.assert_called_once_with('foo')
+    >>> assert result == 'bibble'
+
+
+.. _auto-speccing:
+
+Autospeccing
+============
+
+Autospeccing is based on the existing `spec` feature of mock. It limits the
+api of mocks to the api of an original object (the spec), but it is recursive
+(implemented lazily) so that attributes of mocks only have the same api as
+the attributes of the spec. In addition mocked functions / methods have the
+same call signature as the original so they raise a `TypeError` if they are
+called incorrectly.
+
+Before I explain how auto-speccing works, here's why it is needed.
+
+`Mock` is a very powerful and flexible object, but it suffers from two flaws
+when used to mock out objects from a system under test. One of these flaws is
+specific to the `Mock` api and the other is a more general problem with using
+mock objects.
+
+First the problem specific to `Mock`. `Mock` has two assert methods that are
+extremely handy: :meth:`~Mock.assert_called_with` and
+:meth:`~Mock.assert_called_once_with`.
+
+.. doctest::
+
+    >>> mock = Mock(name='Thing', return_value=None)
+    >>> mock(1, 2, 3)
+    >>> mock.assert_called_once_with(1, 2, 3)
+    >>> mock(1, 2, 3)
+    >>> mock.assert_called_once_with(1, 2, 3)
+    Traceback (most recent call last):
+     ...
+    AssertionError: Expected to be called once. Called 2 times.
+
+Because mocks auto-create attributes on demand, and allow you to call them
+with arbitrary arguments, if you misspell one of these assert methods then
+your assertion is gone:
+
+.. code-block:: pycon
+
+    >>> mock = Mock(name='Thing', return_value=None)
+    >>> mock(1, 2, 3)
+    >>> mock.assret_called_once_with(4, 5, 6)
+
+Your tests can pass silently and incorrectly because of the typo.
+
+The second issue is more general to mocking. If you refactor some of your
+code, rename members and so on, any tests for code that is still using the
+*old api* but uses mocks instead of the real objects will still pass. This
+means your tests can all pass even though your code is broken.
+
+Note that this is another reason why you need integration tests as well as
+unit tests. Testing everything in isolation is all fine and dandy, but if you
+don't test how your units are "wired together" there is still lots of room
+for bugs that tests might have caught.
+
+`mock` already provides a feature to help with this, called speccing. If you
+use a class or instance as the `spec` for a mock then you can only access
+attributes on the mock that exist on the real class:
+
+.. doctest::
+
+    >>> import urllib2
+    >>> mock = Mock(spec=urllib2.Request)
+    >>> mock.assret_called_with
+    Traceback (most recent call last):
+     ...
+    AttributeError: Mock object has no attribute 'assret_called_with'
+
+The spec only applies to the mock itself, so we still have the same issue
+with any methods on the mock:
+
+.. code-block:: pycon
+
+    >>> mock.has_data()
+    <mock.Mock object at 0x...>
+    >>> mock.has_data.assret_called_with()
+
+Auto-speccing solves this problem. You can either pass `autospec=True` to
+`patch` / `patch.object` or use the `create_autospec` function to create a
+mock with a spec. If you use the `autospec=True` argument to `patch` then the
+object that is being replaced will be used as the spec object. Because the
+speccing is done "lazily" (the spec is created as attributes on the mock are
+accessed) you can use it with very complex or deeply nested objects (like
+modules that import modules that import modules) without a big performance
+hit.
+
+Here's an example of it in use:
+
+.. doctest::
+
+    >>> import urllib2
+    >>> patcher = patch('__main__.urllib2', autospec=True)
+    >>> mock_urllib2 = patcher.start()
+    >>> urllib2 is mock_urllib2
+    True
+    >>> urllib2.Request
+    <MagicMock name='urllib2.Request' spec='Request' id='...'>
+
+You can see that `urllib2.Request` has a spec. `urllib2.Request` takes two
+arguments in the constructor (one of which is `self`). Here's what happens if
+we try to call it incorrectly:
+
+.. doctest::
+
+    >>> req = urllib2.Request()
+    Traceback (most recent call last):
+     ...
+    TypeError: <lambda>() takes at least 2 arguments (1 given)
+
+The spec also applies to instantiated classes (i.e. the return value of
+specced mocks):
+
+.. doctest::
+
+    >>> req = urllib2.Request('foo')
+    >>> req
+    <NonCallableMagicMock name='urllib2.Request()' spec='Request' id='...'>
+
+`Request` objects are not callable, so the return value of instantiating our
+mocked out `urllib2.Request` is a non-callable mock. With the spec in place
+any typos in our asserts will raise the correct error:
+
+.. doctest::
+
+    >>> req.add_header('spam', 'eggs')
+    <MagicMock name='urllib2.Request().add_header()' id='...'>
+    >>> req.add_header.assret_called_with
+    Traceback (most recent call last):
+     ...
+    AttributeError: Mock object has no attribute 'assret_called_with'
+    >>> req.add_header.assert_called_with('spam', 'eggs')
+
+In many cases you will just be able to add `autospec=True` to your existing
+`patch` calls and then be protected against bugs due to typos and api
+changes.
+
+As well as using `autospec` through `patch` there is a
+:func:`create_autospec` for creating autospecced mocks directly:
+
+.. doctest::
+
+    >>> import urllib2
+    >>> mock_urllib2 = create_autospec(urllib2)
+    >>> mock_urllib2.Request('foo', 'bar')
+    <NonCallableMagicMock name='mock.Request()' spec='Request' id='...'>
+
+This isn't without caveats and limitations however, which is why it is not
+the default behaviour. In order to know what attributes are available on the
+spec object, autospec has to introspect (access attributes) the spec. As you
+traverse attributes on the mock a corresponding traversal of the original
+object is happening under the hood. If any of your specced objects have
+properties or descriptors that can trigger code execution then you may not be
+able to use autospec. On the other hand it is much better to design your
+objects so that introspection is safe [#]_.
+
+A more serious problem is that it is common for instance attributes to be
+created in the `__init__` method and not to exist on the class at all.
+`autospec` can't know about any dynamically created attributes and restricts
+the api to visible attributes.
+
+.. doctest::
+
+    >>> class Something(object):
+    ...   def __init__(self):
+    ...     self.a = 33
+    ...
+    >>> with patch('__main__.Something', autospec=True):
+    ...   thing = Something()
+    ...   thing.a
+    ...
+    Traceback (most recent call last):
+      ...
+    AttributeError: Mock object has no attribute 'a'
+
+There are a few different ways of resolving this problem. The easiest, but
+not necessarily the least annoying, way is to simply set the required
+attributes on the mock after creation. Just because `autospec` doesn't allow
+you to fetch attributes that don't exist on the spec it doesn't prevent you
+setting them:
+
+.. doctest::
+
+    >>> with patch('__main__.Something', autospec=True):
+    ...   thing = Something()
+    ...   thing.a = 33
+    ...
+
+There is a more aggressive version of both `spec` and `autospec` that *does*
+prevent you setting non-existent attributes. This is useful if you want to
+ensure your code only *sets* valid attributes too, but obviously it prevents
+this particular scenario:
+
+.. doctest::
+
+    >>> with patch('__main__.Something', autospec=True, spec_set=True):
+    ...   thing = Something()
+    ...   thing.a = 33
+    ...
+    Traceback (most recent call last):
+     ...
+    AttributeError: Mock object has no attribute 'a'
+
+Probably the best way of solving the problem is to add class attributes as
+default values for instance members initialised in `__init__`. Note that if
+you are only setting default attributes in `__init__` then providing them via
+class attributes (shared between instances of course) is faster too. e.g.
+
+.. code-block:: python
+
+    class Something(object):
+        a = 33
+
+This brings up another issue. It is relatively common to provide a default
+value of `None` for members that will later be an object of a different type.
+`None` would be useless as a spec because it wouldn't let you access *any*
+attributes or methods on it. As `None` is *never* going to be useful as a
+spec, and probably indicates a member that will normally of some other type,
+`autospec` doesn't use a spec for members that are set to `None`. These will
+just be ordinary mocks (well - `MagicMocks`):
+
+.. doctest::
+
+    >>> class Something(object):
+    ...     member = None
+    ...
+    >>> mock = create_autospec(Something)
+    >>> mock.member.foo.bar.baz()
+    <MagicMock name='mock.member.foo.bar.baz()' id='...'>
+
+If modifying your production classes to add defaults isn't to your liking
+then there are more options. One of these is simply to use an instance as the
+spec rather than the class. The other is to create a subclass of the
+production class and add the defaults to the subclass without affecting the
+production class. Both of these require you to use an alternative object as
+the spec. Thankfully `patch` supports this - you can simply pass the
+alternative object as the `autospec` argument:
+
+.. doctest::
+
+    >>> class Something(object):
+    ...   def __init__(self):
+    ...     self.a = 33
+    ...
+    >>> class SomethingForTest(Something):
+    ...   a = 33
+    ...
+    >>> p = patch('__main__.Something', autospec=SomethingForTest)
+    >>> mock = p.start()
+    >>> mock.a
+    <NonCallableMagicMock name='Something.a' spec='int' id='...'>
+
+.. note::
+
+    An additional limitation (currently) with `autospec` is that unbound
+    methods on mocked classes *don't* take an "explicit self" as the first
+    argument - so this usage will fail with `autospec`.
+
+    .. doctest::
+
+        >>> class Foo(object):
+        ...   def foo(self):
+        ...     pass
+        ...
+        >>> Foo.foo(Foo())
+        >>> MockFoo = create_autospec(Foo)
+        >>> MockFoo.foo(MockFoo())
+        Traceback (most recent call last):
+          ...
+        TypeError: <lambda>() takes exactly 1 argument (2 given)
+
+    The reason is that its very hard to tell the difference between functions,
+    unbound methods and staticmethods across Python 2 & 3 and the alternative
+    implementations. This restriction may be fixed in future versions.
+
+
+------
+
+.. [#] This only applies to classes or already instantiated objects. Calling
+   a mocked class to create a mock instance *does not* create a real instance.
+   It is only attribute lookups - along with calls to `dir` - that are done. A
+   way round this problem would have been to use `getattr_static
+   <http://docs.python.org/dev/library/inspect.html#inspect.getattr_static>`_,
+   which can fetch attributes without triggering code execution. Descriptors
+   like `classmethod` and `staticmethod` *need* to be fetched correctly though,
+   so that their signatures can be mocked correctly.

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/index.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/index.txt
@@ -1,0 +1,411 @@
+====================================
+ Mock - Mocking and Testing Library
+====================================
+
+.. currentmodule:: mock
+
+:Author: `Michael Foord
+ <http://www.voidspace.org.uk/python/weblog/index.shtml>`_
+:Version: |release|
+:Date: 2012/10/07
+:Homepage: `Mock Homepage`_
+:Download: `Mock on PyPI`_
+:Documentation: `PDF Documentation
+ <http://www.voidspace.org.uk/downloads/mock-1.0.1.pdf>`_
+:License: `BSD License`_
+:Support: `Mailing list (testing-in-python@lists.idyll.org)
+ <http://lists.idyll.org/listinfo/testing-in-python>`_
+:Issue tracker: `Google code project
+ <http://code.google.com/p/mock/issues/list>`_
+
+.. _Mock Homepage: http://www.voidspace.org.uk/python/mock/
+.. _BSD License: http://www.voidspace.org.uk/python/license.shtml
+
+
+.. currentmodule:: mock
+
+.. module:: mock
+   :synopsis: Mock object and testing library.
+
+.. index:: introduction
+
+mock is a library for testing in Python. It allows you to replace parts of
+your system under test with mock objects and make assertions about how they
+have been used.
+
+mock is now part of the Python standard library, available as `unittest.mock
+<http://docs.python.org/py3k/library/unittest.mock.html#module-unittest.mock>`_
+in Python 3.3 onwards.
+
+mock provides a core :class:`Mock` class removing the need to create a host
+of stubs throughout your test suite. After performing an action, you can make
+assertions about which methods / attributes were used and arguments they were
+called with. You can also specify return values and set needed attributes in
+the normal way.
+
+Additionally, mock provides a :func:`patch` decorator that handles patching
+module and class level attributes within the scope of a test, along with
+:const:`sentinel` for creating unique objects. See the `quick guide`_ for
+some examples of how to use :class:`Mock`, :class:`MagicMock` and
+:func:`patch`.
+
+Mock is very easy to use and is designed for use with
+`unittest <http://pypi.python.org/pypi/unittest2>`_. Mock is based on
+the 'action -> assertion' pattern instead of `'record -> replay'` used by many
+mocking frameworks.
+
+mock is tested on Python versions 2.4-2.7, Python 3 plus the latest versions of
+Jython and PyPy.
+
+
+.. testsetup::
+
+   class ProductionClass(object):
+      def method(self, *args):
+         pass
+
+   module = sys.modules['module'] = ProductionClass
+   ProductionClass.ClassName1 = ProductionClass
+   ProductionClass.ClassName2 = ProductionClass
+
+
+
+API Documentation
+=================
+
+.. toctree::
+   :maxdepth: 2
+
+   mock
+   patch
+   helpers
+   sentinel
+   magicmock
+
+
+User Guide
+==========
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   examples
+   compare
+   changelog
+
+
+.. index:: installing
+
+Installing
+==========
+
+The current version is |release|. Mock is stable and widely used. If you do
+find any bugs, or have suggestions for improvements / extensions
+then please contact us.
+
+* `mock on PyPI <http://pypi.python.org/pypi/mock>`_
+* `mock documentation as PDF
+  <http://www.voidspace.org.uk/downloads/mock-1.0.1.pdf>`_
+* `Google Code Home & Mercurial Repository <http://code.google.com/p/mock/>`_
+
+.. index:: repository
+.. index:: hg
+
+You can checkout the latest development version from the Google Code Mercurial
+repository with the following command:
+
+    ``hg clone https://mock.googlecode.com/hg/ mock``
+
+
+.. index:: pip
+.. index:: easy_install
+.. index:: setuptools
+
+If you have pip, setuptools or distribute you can install mock with:
+
+    | ``easy_install -U mock``
+    | ``pip install -U mock``
+
+Alternatively you can download the mock distribution from PyPI and after
+unpacking run:
+
+   ``python setup.py install``
+
+
+Quick Guide
+===========
+
+:class:`Mock` and :class:`MagicMock` objects create all attributes and
+methods as you access them and store details of how they have been used. You
+can configure them, to specify return values or limit what attributes are
+available, and then make assertions about how they have been used:
+
+.. doctest::
+
+    >>> from mock import MagicMock
+    >>> thing = ProductionClass()
+    >>> thing.method = MagicMock(return_value=3)
+    >>> thing.method(3, 4, 5, key='value')
+    3
+    >>> thing.method.assert_called_with(3, 4, 5, key='value')
+
+:attr:`side_effect` allows you to perform side effects, including raising an
+exception when a mock is called:
+
+.. doctest::
+
+   >>> mock = Mock(side_effect=KeyError('foo'))
+   >>> mock()
+   Traceback (most recent call last):
+    ...
+   KeyError: 'foo'
+
+   >>> values = {'a': 1, 'b': 2, 'c': 3}
+   >>> def side_effect(arg):
+   ...     return values[arg]
+   ...
+   >>> mock.side_effect = side_effect
+   >>> mock('a'), mock('b'), mock('c')
+   (1, 2, 3)
+   >>> mock.side_effect = [5, 4, 3, 2, 1]
+   >>> mock(), mock(), mock()
+   (5, 4, 3)
+
+Mock has many other ways you can configure it and control its behaviour. For
+example the `spec` argument configures the mock to take its specification
+from another object. Attempting to access attributes or methods on the mock
+that don't exist on the spec will fail with an `AttributeError`.
+
+The :func:`patch` decorator / context manager makes it easy to mock classes or
+objects in a module under test. The object you specify will be replaced with a
+mock (or other object) during the test and restored when the test ends:
+
+.. doctest::
+
+    >>> from mock import patch
+    >>> @patch('module.ClassName2')
+    ... @patch('module.ClassName1')
+    ... def test(MockClass1, MockClass2):
+    ...     module.ClassName1()
+    ...     module.ClassName2()
+
+    ...     assert MockClass1 is module.ClassName1
+    ...     assert MockClass2 is module.ClassName2
+    ...     assert MockClass1.called
+    ...     assert MockClass2.called
+    ...
+    >>> test()
+
+.. note::
+
+   When you nest patch decorators the mocks are passed in to the decorated
+   function in the same order they applied (the normal *python* order that
+   decorators are applied). This means from the bottom up, so in the example
+   above the mock for `module.ClassName1` is passed in first.
+
+   With `patch` it matters that you patch objects in the namespace where they
+   are looked up. This is normally straightforward, but for a quick guide
+   read :ref:`where to patch <where-to-patch>`.
+
+As well as a decorator `patch` can be used as a context manager in a with
+statement:
+
+.. doctest::
+
+    >>> with patch.object(ProductionClass, 'method', return_value=None) as mock_method:
+    ...     thing = ProductionClass()
+    ...     thing.method(1, 2, 3)
+    ...
+    >>> mock_method.assert_called_once_with(1, 2, 3)
+
+
+There is also :func:`patch.dict` for setting values in a dictionary just
+during a scope and restoring the dictionary to its original state when the test
+ends:
+
+.. doctest::
+
+   >>> foo = {'key': 'value'}
+   >>> original = foo.copy()
+   >>> with patch.dict(foo, {'newkey': 'newvalue'}, clear=True):
+   ...     assert foo == {'newkey': 'newvalue'}
+   ...
+   >>> assert foo == original
+
+Mock supports the mocking of Python :ref:`magic methods <magic-methods>`. The
+easiest way of using magic methods is with the :class:`MagicMock` class. It
+allows you to do things like:
+
+.. doctest::
+
+    >>> mock = MagicMock()
+    >>> mock.__str__.return_value = 'foobarbaz'
+    >>> str(mock)
+    'foobarbaz'
+    >>> mock.__str__.assert_called_with()
+
+Mock allows you to assign functions (or other Mock instances) to magic methods
+and they will be called appropriately. The `MagicMock` class is just a Mock
+variant that has all of the magic methods pre-created for you (well, all the
+useful ones anyway).
+
+The following is an example of using magic methods with the ordinary Mock
+class:
+
+.. doctest::
+
+    >>> mock = Mock()
+    >>> mock.__str__ = Mock(return_value='wheeeeee')
+    >>> str(mock)
+    'wheeeeee'
+
+For ensuring that the mock objects in your tests have the same api as the
+objects they are replacing, you can use :ref:`auto-speccing <auto-speccing>`.
+Auto-speccing can be done through the `autospec` argument to patch, or the
+:func:`create_autospec` function. Auto-speccing creates mock objects that
+have the same attributes and methods as the objects they are replacing, and
+any functions and methods (including constructors) have the same call
+signature as the real object.
+
+This ensures that your mocks will fail in the same way as your production
+code if they are used incorrectly:
+
+.. doctest::
+
+   >>> from mock import create_autospec
+   >>> def function(a, b, c):
+   ...     pass
+   ...
+   >>> mock_function = create_autospec(function, return_value='fishy')
+   >>> mock_function(1, 2, 3)
+   'fishy'
+   >>> mock_function.assert_called_once_with(1, 2, 3)
+   >>> mock_function('wrong arguments')
+   Traceback (most recent call last):
+    ...
+   TypeError: <lambda>() takes exactly 3 arguments (1 given)
+
+`create_autospec` can also be used on classes, where it copies the signature of
+the `__init__` method, and on callable objects where it copies the signature of
+the `__call__` method.
+
+
+.. index:: references
+.. index:: articles
+
+References
+==========
+
+Articles, blog entries and other stuff related to testing with Mock:
+
+* `Imposing a No DB Discipline on Django unit tests
+  <https://github.com/carljm/django-testing-slides/blob/master/models/30_no_database.md>`_
+* `mock-django: tools for mocking the Django ORM and models
+  <https://github.com/dcramer/mock-django>`_
+* `PyCon 2011 Video: Testing with mock <https://blip.tv/file/4881513>`_
+* `Mock objects in Python
+  <http://noopenblockers.com/2012/01/06/mock-objects-in-python/>`_
+* `Python: Injecting Mock Objects for Powerful Testing
+  <http://blueprintforge.com/blog/2012/01/08/python-injecting-mock-objects-for-powerful-testing/>`_
+* `Python Mock: How to assert a substring of logger output
+  <http://www.michaelpollmeier.com/python-mock-how-to-assert-a-substring-of-logger-output/>`_
+* `Mocking Django <http://www.mattjmorrison.com/2011/09/mocking-django.html>`_
+* `Mocking dates and other classes that can't be modified
+  <http://williamjohnbert.com/2011/07/how-to-unit-testing-in-django-with-mocking-and-patching/>`_
+* `Mock recipes <http://konryd.blogspot.com/2010/06/mock-recipies.html>`_
+* `Mockity mock mock - some love for the mock module
+  <http://konryd.blogspot.com/2010/05/mockity-mock-mock-some-love-for-mock.html>`_
+* `Coverage and Mock (with django)
+  <http://mattsnider.com/python/mock-and-coverage/>`_
+* `Python Unit Testing with Mock <http://www.insomnihack.com/?p=194>`_
+* `Getting started with Python Mock
+  <http://myadventuresincoding.wordpress.com/2011/02/26/python-python-mock-cheat-sheet/>`_
+* `Smart Parameter Checks with mock
+  <http://tobyho.com/2011/03/24/smart-parameter-checks-in/>`_
+* `Python mock testing techniques and tools
+  <http://agiletesting.blogspot.com/2009/07/python-mock-testing-techniques-and.html>`_
+* `How To Test Django Template Tags
+  <http://techblog.ironfroggy.com/2008/10/how-to-test.html>`_
+* `A presentation on Unit Testing with Mock
+  <http://pypap.blogspot.com/2008/10/newbie-nugget-unit-testing-with-mock.html>`_
+* `Mocking with Django and Google AppEngine
+  <http://michael-a-nelson.blogspot.com/2008/09/mocking-with-django-and-google-app.html>`_
+
+
+.. index:: tests
+.. index:: unittest2
+
+Tests
+=====
+
+Mock uses `unittest2 <http://pypi.python.org/pypi/unittest2>`_ for its own
+test suite. In order to run it, use the `unit2` script that comes with
+`unittest2` module on a checkout of the source repository:
+
+   `unit2 discover`
+
+If you have `setuptools <http://pypi.python.org/pypi/distribute>`_ as well as
+unittest2 you can run:
+
+   ``python setup.py test``
+
+On Python 3.2 you can use ``unittest`` module from the standard library.
+
+   ``python3.2 -m unittest discover``
+
+.. index:: Python 3
+
+On Python 3 the tests for unicode are skipped as they are not relevant. On
+Python 2.4 tests that use the with statements are skipped as the with statement
+is invalid syntax on Python 2.4.
+
+
+.. index:: older versions
+
+Older Versions
+==============
+
+Documentation for older versions of mock:
+
+* `mock 0.8 <http://www.voidspace.org.uk/python/mock/0.8/>`_
+* `mock 0.7 <http://www.voidspace.org.uk/python/mock/0.7/>`_
+* `mock 0.6 <http://www.voidspace.org.uk/python/mock/0.6.0/>`_
+
+Docs from the in-development version of `mock` can be found at
+`mock.readthedocs.org <http://mock.readthedocs.org>`_.
+
+
+Terminology
+===========
+
+Terminology for objects used to replace other ones can be confusing. Terms
+like double, fake, mock, stub, and spy are all used with varying meanings.
+
+In `classic mock terminology
+<http://xunitpatterns.com/Mocks,%20Fakes,%20Stubs%20and%20Dummies.html>`_
+:class:`mock.Mock` is a `spy <http://xunitpatterns.com/Test%20Spy.html>`_ that
+allows for *post-mortem* examination. This is what I call the "action ->
+assertion" [#]_ pattern of testing.
+
+I'm not however a fan of this "statically typed mocking terminology"
+promulgated by `Martin Fowler
+<http://martinfowler.com/articles/mocksArentStubs.html>`_. It confuses usage
+patterns with implementation and prevents you from using natural terminology
+when discussing mocking.
+
+I much prefer duck typing, if an object used in your test suite looks like a
+mock object and quacks like a mock object then it's fine to call it a mock, no
+matter what the implementation looks like.
+
+This terminology is perhaps more useful in less capable languages where
+different usage patterns will *require* different implementations.
+`mock.Mock()` is capable of being used in most of the different roles
+described by Fowler, except (annoyingly / frustratingly / ironically) a Mock
+itself!
+
+How about a simpler definition: a "mock object" is an object used to replace a
+real one in a system under test.
+
+.. [#] This pattern is called "AAA" by some members of the testing community;
+   "Arrange - Act - Assert".

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/magicmock.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/magicmock.txt
@@ -1,0 +1,258 @@
+
+.. currentmodule:: mock
+
+
+.. _magic-methods:
+
+Mocking Magic Methods
+=====================
+
+.. currentmodule:: mock
+
+:class:`Mock` supports mocking `magic methods
+<http://www.ironpythoninaction.com/magic-methods.html>`_. This allows mock
+objects to replace containers or other objects that implement Python
+protocols.
+
+Because magic methods are looked up differently from normal methods [#]_, this
+support has been specially implemented. This means that only specific magic
+methods are supported. The supported list includes *almost* all of them. If
+there are any missing that you need please let us know!
+
+You mock magic methods by setting the method you are interested in to a function
+or a mock instance. If you are using a function then it *must* take ``self`` as
+the first argument [#]_.
+
+.. doctest::
+
+   >>> def __str__(self):
+   ...     return 'fooble'
+   ...
+   >>> mock = Mock()
+   >>> mock.__str__ = __str__
+   >>> str(mock)
+   'fooble'
+
+   >>> mock = Mock()
+   >>> mock.__str__ = Mock()
+   >>> mock.__str__.return_value = 'fooble'
+   >>> str(mock)
+   'fooble'
+
+   >>> mock = Mock()
+   >>> mock.__iter__ = Mock(return_value=iter([]))
+   >>> list(mock)
+   []
+
+One use case for this is for mocking objects used as context managers in a
+`with` statement:
+
+.. doctest::
+
+   >>> mock = Mock()
+   >>> mock.__enter__ = Mock(return_value='foo')
+   >>> mock.__exit__ = Mock(return_value=False)
+   >>> with mock as m:
+   ...     assert m == 'foo'
+   ...
+   >>> mock.__enter__.assert_called_with()
+   >>> mock.__exit__.assert_called_with(None, None, None)
+
+Calls to magic methods do not appear in :attr:`~Mock.method_calls`, but they
+are recorded in :attr:`~Mock.mock_calls`.
+
+.. note::
+
+   If you use the `spec` keyword argument to create a mock then attempting to
+   set a magic method that isn't in the spec will raise an `AttributeError`.
+
+The full list of supported magic methods is:
+
+* ``__hash__``, ``__sizeof__``, ``__repr__`` and ``__str__``
+* ``__dir__``, ``__format__`` and ``__subclasses__``
+* ``__floor__``, ``__trunc__`` and ``__ceil__``
+* Comparisons: ``__cmp__``, ``__lt__``, ``__gt__``, ``__le__``, ``__ge__``,
+  ``__eq__`` and ``__ne__``
+* Container methods: ``__getitem__``, ``__setitem__``, ``__delitem__``,
+  ``__contains__``, ``__len__``, ``__iter__``, ``__getslice__``,
+  ``__setslice__``, ``__reversed__`` and ``__missing__``
+* Context manager: ``__enter__`` and ``__exit__``
+* Unary numeric methods: ``__neg__``, ``__pos__`` and ``__invert__``
+* The numeric methods (including right hand and in-place variants):
+  ``__add__``, ``__sub__``, ``__mul__``, ``__div__``,
+  ``__floordiv__``, ``__mod__``, ``__divmod__``, ``__lshift__``,
+  ``__rshift__``, ``__and__``, ``__xor__``, ``__or__``, and ``__pow__``
+* Numeric conversion methods: ``__complex__``, ``__int__``, ``__float__``,
+  ``__index__`` and ``__coerce__``
+* Descriptor methods: ``__get__``, ``__set__`` and ``__delete__``
+* Pickling: ``__reduce__``, ``__reduce_ex__``, ``__getinitargs__``,
+  ``__getnewargs__``, ``__getstate__`` and ``__setstate__``
+
+
+The following methods are supported in Python 2 but don't exist in Python 3:
+
+* ``__unicode__``, ``__long__``, ``__oct__``, ``__hex__`` and ``__nonzero__``
+*  ``__truediv__`` and ``__rtruediv__``
+
+The following methods are supported in Python 3 but don't exist in Python 2:
+
+* ``__bool__`` and ``__next__``
+
+The following methods exist but are *not* supported as they are either in use by
+mock, can't be set dynamically, or can cause problems:
+
+* ``__getattr__``, ``__setattr__``, ``__init__`` and ``__new__``
+* ``__prepare__``, ``__instancecheck__``, ``__subclasscheck__``, ``__del__``
+
+
+
+Magic Mock
+==========
+
+There are two `MagicMock` variants: `MagicMock` and `NonCallableMagicMock`.
+
+
+.. class:: MagicMock(*args, **kw)
+
+   ``MagicMock`` is a subclass of :class:`Mock` with default implementations
+   of most of the magic methods. You can use ``MagicMock`` without having to
+   configure the magic methods yourself.
+
+   The constructor parameters have the same meaning as for :class:`Mock`.
+
+   If you use the `spec` or `spec_set` arguments then *only* magic methods
+   that exist in the spec will be created.
+
+
+.. class:: NonCallableMagicMock(*args, **kw)
+
+    A non-callable version of `MagicMock`.
+
+    The constructor parameters have the same meaning as for
+    :class:`MagicMock`, with the exception of `return_value` and
+    `side_effect` which have no meaning on a non-callable mock.
+
+The magic methods are setup with `MagicMock` objects, so you can configure them
+and use them in the usual way:
+
+.. doctest::
+
+   >>> mock = MagicMock()
+   >>> mock[3] = 'fish'
+   >>> mock.__setitem__.assert_called_with(3, 'fish')
+   >>> mock.__getitem__.return_value = 'result'
+   >>> mock[2]
+   'result'
+
+By default many of the protocol methods are required to return objects of a
+specific type. These methods are preconfigured with a default return value, so
+that they can be used without you having to do anything if you aren't interested
+in the return value. You can still *set* the return value manually if you want
+to change the default.
+
+Methods and their defaults:
+
+* ``__lt__``: NotImplemented
+* ``__gt__``: NotImplemented
+* ``__le__``: NotImplemented
+* ``__ge__``: NotImplemented
+* ``__int__`` : 1
+* ``__contains__`` : False
+* ``__len__`` : 1
+* ``__iter__`` : iter([])
+* ``__exit__`` : False
+* ``__complex__`` : 1j
+* ``__float__`` : 1.0
+* ``__bool__`` : True
+* ``__nonzero__`` : True
+* ``__oct__`` : '1'
+* ``__hex__`` : '0x1'
+* ``__long__`` : long(1)
+* ``__index__`` : 1
+* ``__hash__`` : default hash for the mock
+* ``__str__`` : default str for the mock
+* ``__unicode__`` : default unicode for the mock
+* ``__sizeof__``: default sizeof for the mock
+
+For example:
+
+.. doctest::
+
+   >>> mock = MagicMock()
+   >>> int(mock)
+   1
+   >>> len(mock)
+   0
+   >>> hex(mock)
+   '0x1'
+   >>> list(mock)
+   []
+   >>> object() in mock
+   False
+
+The two equality method, `__eq__` and `__ne__`, are special (changed in
+0.7.2). They do the default equality comparison on identity, using a side
+effect, unless you change their return value to return something else:
+
+.. doctest::
+
+   >>> MagicMock() == 3
+   False
+   >>> MagicMock() != 3
+   True
+   >>> mock = MagicMock()
+   >>> mock.__eq__.return_value = True
+   >>> mock == 3
+   True
+
+In `0.8` the `__iter__` also gained special handling implemented with a
+side effect. The return value of `MagicMock.__iter__` can be any iterable
+object and isn't required to be an iterator:
+
+.. doctest::
+
+   >>> mock = MagicMock()
+   >>> mock.__iter__.return_value = ['a', 'b', 'c']
+   >>> list(mock)
+   ['a', 'b', 'c']
+   >>> list(mock)
+   ['a', 'b', 'c']
+
+If the return value *is* an iterator, then iterating over it once will consume
+it and subsequent iterations will result in an empty list:
+
+.. doctest::
+
+   >>> mock.__iter__.return_value = iter(['a', 'b', 'c'])
+   >>> list(mock)
+   ['a', 'b', 'c']
+   >>> list(mock)
+   []
+
+``MagicMock`` has all of the supported magic methods configured except for some
+of the obscure and obsolete ones. You can still set these up if you want.
+
+Magic methods that are supported but not setup by default in ``MagicMock`` are:
+
+* ``__cmp__``
+* ``__getslice__`` and ``__setslice__``
+* ``__coerce__``
+* ``__subclasses__``
+* ``__dir__``
+* ``__format__``
+* ``__get__``, ``__set__`` and ``__delete__``
+* ``__reversed__`` and ``__missing__``
+* ``__reduce__``, ``__reduce_ex__``, ``__getinitargs__``, ``__getnewargs__``,
+  ``__getstate__`` and ``__setstate__``
+* ``__getformat__`` and ``__setformat__``
+
+
+
+------------
+
+.. [#] Magic methods *should* be looked up on the class rather than the
+   instance. Different versions of Python are inconsistent about applying this
+   rule. The supported protocol methods should work with all supported versions
+   of Python.
+.. [#] The function is basically hooked up to the class, but each ``Mock``
+   instance is kept isolated from the others.

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/mock.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/mock.txt
@@ -1,0 +1,842 @@
+The Mock Class
+==============
+
+.. currentmodule:: mock
+
+.. testsetup::
+
+    class SomeClass:
+        pass
+
+
+`Mock` is a flexible mock object intended to replace the use of stubs and
+test doubles throughout your code. Mocks are callable and create attributes as
+new mocks when you access them [#]_. Accessing the same attribute will always
+return the same mock. Mocks record how you use them, allowing you to make
+assertions about what your code has done to them.
+
+:class:`MagicMock` is a subclass of `Mock` with all the magic methods
+pre-created and ready to use. There are also non-callable variants, useful
+when you are mocking out objects that aren't callable:
+:class:`NonCallableMock` and :class:`NonCallableMagicMock`
+
+The :func:`patch` decorators makes it easy to temporarily replace classes
+in a particular module with a `Mock` object. By default `patch` will create
+a `MagicMock` for you. You can specify an alternative class of `Mock` using
+the `new_callable` argument to `patch`.
+
+
+.. index:: side_effect
+.. index:: return_value
+.. index:: wraps
+.. index:: name
+.. index:: spec
+
+.. class:: Mock(spec=None, side_effect=None, return_value=DEFAULT, wraps=None, name=None, spec_set=None, **kwargs)
+
+    Create a new `Mock` object. `Mock` takes several optional arguments
+    that specify the behaviour of the Mock object:
+
+    * `spec`: This can be either a list of strings or an existing object (a
+      class or instance) that acts as the specification for the mock object. If
+      you pass in an object then a list of strings is formed by calling dir on
+      the object (excluding unsupported magic attributes and methods).
+      Accessing any attribute not in this list will raise an `AttributeError`.
+
+      If `spec` is an object (rather than a list of strings) then
+      :attr:`__class__` returns the class of the spec object. This allows mocks
+      to pass `isinstance` tests.
+
+    * `spec_set`: A stricter variant of `spec`. If used, attempting to *set*
+      or get an attribute on the mock that isn't on the object passed as
+      `spec_set` will raise an `AttributeError`.
+
+    * `side_effect`: A function to be called whenever the Mock is called. See
+      the :attr:`~Mock.side_effect` attribute. Useful for raising exceptions or
+      dynamically changing return values. The function is called with the same
+      arguments as the mock, and unless it returns :data:`DEFAULT`, the return
+      value of this function is used as the return value.
+
+      Alternatively `side_effect` can be an exception class or instance. In
+      this case the exception will be raised when the mock is called.
+
+      If `side_effect` is an iterable then each call to the mock will return
+      the next value from the iterable. If any of the members of the iterable
+      are exceptions they will be raised instead of returned.
+
+      A `side_effect` can be cleared by setting it to `None`.
+
+    * `return_value`: The value returned when the mock is called. By default
+      this is a new Mock (created on first access). See the
+      :attr:`return_value` attribute.
+
+    * `wraps`: Item for the mock object to wrap. If `wraps` is not None then
+      calling the Mock will pass the call through to the wrapped object
+      (returning the real result and ignoring `return_value`). Attribute access
+      on the mock will return a Mock object that wraps the corresponding
+      attribute of the wrapped object (so attempting to access an attribute
+      that doesn't exist will raise an `AttributeError`).
+
+      If the mock has an explicit `return_value` set then calls are not passed
+      to the wrapped object and the `return_value` is returned instead.
+
+    * `name`: If the mock has a name then it will be used in the repr of the
+      mock. This can be useful for debugging. The name is propagated to child
+      mocks.
+
+    Mocks can also be called with arbitrary keyword arguments. These will be
+    used to set attributes on the mock after it is created. See the
+    :meth:`configure_mock` method for details.
+
+
+    .. method:: assert_called_with(*args, **kwargs)
+
+        This method is a convenient way of asserting that calls are made in a
+        particular way:
+
+        .. doctest::
+
+            >>> mock = Mock()
+            >>> mock.method(1, 2, 3, test='wow')
+            <Mock name='mock.method()' id='...'>
+            >>> mock.method.assert_called_with(1, 2, 3, test='wow')
+
+
+    .. method:: assert_called_once_with(*args, **kwargs)
+
+       Assert that the mock was called exactly once and with the specified
+       arguments.
+
+       .. doctest::
+
+            >>> mock = Mock(return_value=None)
+            >>> mock('foo', bar='baz')
+            >>> mock.assert_called_once_with('foo', bar='baz')
+            >>> mock('foo', bar='baz')
+            >>> mock.assert_called_once_with('foo', bar='baz')
+            Traceback (most recent call last):
+              ...
+            AssertionError: Expected to be called once. Called 2 times.
+
+
+    .. method:: assert_any_call(*args, **kwargs)
+
+        assert the mock has been called with the specified arguments.
+
+        The assert passes if the mock has *ever* been called, unlike
+        :meth:`assert_called_with` and :meth:`assert_called_once_with` that
+        only pass if the call is the most recent one.
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=None)
+            >>> mock(1, 2, arg='thing')
+            >>> mock('some', 'thing', 'else')
+            >>> mock.assert_any_call(1, 2, arg='thing')
+
+
+    .. method:: assert_has_calls(calls, any_order=False)
+
+        assert the mock has been called with the specified calls.
+        The `mock_calls` list is checked for the calls.
+
+        If `any_order` is False (the default) then the calls must be
+        sequential. There can be extra calls before or after the
+        specified calls.
+
+        If `any_order` is True then the calls can be in any order, but
+        they must all appear in :attr:`mock_calls`.
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=None)
+            >>> mock(1)
+            >>> mock(2)
+            >>> mock(3)
+            >>> mock(4)
+            >>> calls = [call(2), call(3)]
+            >>> mock.assert_has_calls(calls)
+            >>> calls = [call(4), call(2), call(3)]
+            >>> mock.assert_has_calls(calls, any_order=True)
+
+
+    .. method:: reset_mock()
+
+        The reset_mock method resets all the call attributes on a mock object:
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=None)
+            >>> mock('hello')
+            >>> mock.called
+            True
+            >>> mock.reset_mock()
+            >>> mock.called
+            False
+
+        This can be useful where you want to make a series of assertions that
+        reuse the same object. Note that `reset_mock` *doesn't* clear the
+        return value, :attr:`side_effect` or any child attributes you have
+        set using normal assignment. Child mocks and the return value mock
+        (if any) are reset as well.
+
+
+    .. method:: mock_add_spec(spec, spec_set=False)
+
+        Add a spec to a mock. `spec` can either be an object or a
+        list of strings. Only attributes on the `spec` can be fetched as
+        attributes from the mock.
+
+        If `spec_set` is `True` then only attributes on the spec can be set.
+
+
+    .. method:: attach_mock(mock, attribute)
+
+        Attach a mock as an attribute of this one, replacing its name and
+        parent. Calls to the attached mock will be recorded in the
+        :attr:`method_calls` and :attr:`mock_calls` attributes of this one.
+
+
+    .. method:: configure_mock(**kwargs)
+
+        Set attributes on the mock through keyword arguments.
+
+        Attributes plus return values and side effects can be set on child
+        mocks using standard dot notation and unpacking a dictionary in the
+        method call:
+
+        .. doctest::
+
+            >>> mock = Mock()
+            >>> attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
+            >>> mock.configure_mock(**attrs)
+            >>> mock.method()
+            3
+            >>> mock.other()
+            Traceback (most recent call last):
+              ...
+            KeyError
+
+        The same thing can be achieved in the constructor call to mocks:
+
+        .. doctest::
+
+            >>> attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
+            >>> mock = Mock(some_attribute='eggs', **attrs)
+            >>> mock.some_attribute
+            'eggs'
+            >>> mock.method()
+            3
+            >>> mock.other()
+            Traceback (most recent call last):
+              ...
+            KeyError
+
+        `configure_mock` exists to make it easier to do configuration
+        after the mock has been created.
+
+
+    .. method:: __dir__()
+
+        `Mock` objects limit the results of `dir(some_mock)` to useful results.
+        For mocks with a `spec` this includes all the permitted attributes
+        for the mock.
+
+        See :data:`FILTER_DIR` for what this filtering does, and how to
+        switch it off.
+
+
+    .. method:: _get_child_mock(**kw)
+
+        Create the child mocks for attributes and return value.
+        By default child mocks will be the same type as the parent.
+        Subclasses of Mock may want to override this to customize the way
+        child mocks are made.
+
+        For non-callable mocks the callable variant will be used (rather than
+        any custom subclass).
+
+
+    .. attribute:: called
+
+        A boolean representing whether or not the mock object has been called:
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=None)
+            >>> mock.called
+            False
+            >>> mock()
+            >>> mock.called
+            True
+
+    .. attribute:: call_count
+
+        An integer telling you how many times the mock object has been called:
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=None)
+            >>> mock.call_count
+            0
+            >>> mock()
+            >>> mock()
+            >>> mock.call_count
+            2
+
+
+    .. attribute:: return_value
+
+        Set this to configure the value returned by calling the mock:
+
+        .. doctest::
+
+            >>> mock = Mock()
+            >>> mock.return_value = 'fish'
+            >>> mock()
+            'fish'
+
+        The default return value is a mock object and you can configure it in
+        the normal way:
+
+        .. doctest::
+
+            >>> mock = Mock()
+            >>> mock.return_value.attribute = sentinel.Attribute
+            >>> mock.return_value()
+            <Mock name='mock()()' id='...'>
+            >>> mock.return_value.assert_called_with()
+
+        `return_value` can also be set in the constructor:
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=3)
+            >>> mock.return_value
+            3
+            >>> mock()
+            3
+
+
+    .. attribute:: side_effect
+
+        This can either be a function to be called when the mock is called,
+        or an exception (class or instance) to be raised.
+
+        If you pass in a function it will be called with same arguments as the
+        mock and unless the function returns the :data:`DEFAULT` singleton the
+        call to the mock will then return whatever the function returns. If the
+        function returns :data:`DEFAULT` then the mock will return its normal
+        value (from the :attr:`return_value`.
+
+        An example of a mock that raises an exception (to test exception
+        handling of an API):
+
+        .. doctest::
+
+            >>> mock = Mock()
+            >>> mock.side_effect = Exception('Boom!')
+            >>> mock()
+            Traceback (most recent call last):
+              ...
+            Exception: Boom!
+
+        Using `side_effect` to return a sequence of values:
+
+        .. doctest::
+
+            >>> mock = Mock()
+            >>> mock.side_effect = [3, 2, 1]
+            >>> mock(), mock(), mock()
+            (3, 2, 1)
+
+        The `side_effect` function is called with the same arguments as the
+        mock (so it is wise for it to take arbitrary args and keyword
+        arguments) and whatever it returns is used as the return value for
+        the call. The exception is if `side_effect` returns :data:`DEFAULT`,
+        in which case the normal :attr:`return_value` is used.
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=3)
+            >>> def side_effect(*args, **kwargs):
+            ...     return DEFAULT
+            ...
+            >>> mock.side_effect = side_effect
+            >>> mock()
+            3
+
+        `side_effect` can be set in the constructor. Here's an example that
+        adds one to the value the mock is called with and returns it:
+
+        .. doctest::
+
+            >>> side_effect = lambda value: value + 1
+            >>> mock = Mock(side_effect=side_effect)
+            >>> mock(3)
+            4
+            >>> mock(-8)
+            -7
+
+        Setting `side_effect` to `None` clears it:
+
+        .. doctest::
+
+            >>> from mock import Mock
+            >>> m = Mock(side_effect=KeyError, return_value=3)
+            >>> m()
+            Traceback (most recent call last):
+             ...
+            KeyError
+            >>> m.side_effect = None
+            >>> m()
+            3
+
+
+    .. attribute:: call_args
+
+        This is either `None` (if the mock hasn't been called), or the
+        arguments that the mock was last called with. This will be in the
+        form of a tuple: the first member is any ordered arguments the mock
+        was called with (or an empty tuple) and the second member is any
+        keyword arguments (or an empty dictionary).
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=None)
+            >>> print mock.call_args
+            None
+            >>> mock()
+            >>> mock.call_args
+            call()
+            >>> mock.call_args == ()
+            True
+            >>> mock(3, 4)
+            >>> mock.call_args
+            call(3, 4)
+            >>> mock.call_args == ((3, 4),)
+            True
+            >>> mock(3, 4, 5, key='fish', next='w00t!')
+            >>> mock.call_args
+            call(3, 4, 5, key='fish', next='w00t!')
+
+        `call_args`, along with members of the lists :attr:`call_args_list`,
+        :attr:`method_calls` and :attr:`mock_calls` are :data:`call` objects.
+        These are tuples, so they can be unpacked to get at the individual
+        arguments and make more complex assertions. See
+        :ref:`calls as tuples <calls-as-tuples>`.
+
+
+    .. attribute:: call_args_list
+
+        This is a list of all the calls made to the mock object in sequence
+        (so the length of the list is the number of times it has been
+        called). Before any calls have been made it is an empty list. The
+        :data:`call` object can be used for conveniently constructing lists of
+        calls to compare with `call_args_list`.
+
+        .. doctest::
+
+            >>> mock = Mock(return_value=None)
+            >>> mock()
+            >>> mock(3, 4)
+            >>> mock(key='fish', next='w00t!')
+            >>> mock.call_args_list
+            [call(), call(3, 4), call(key='fish', next='w00t!')]
+            >>> expected = [(), ((3, 4),), ({'key': 'fish', 'next': 'w00t!'},)]
+            >>> mock.call_args_list == expected
+            True
+
+        Members of `call_args_list` are :data:`call` objects. These can be
+        unpacked as tuples to get at the individual arguments. See
+        :ref:`calls as tuples <calls-as-tuples>`.
+
+
+    .. attribute:: method_calls
+
+        As well as tracking calls to themselves, mocks also track calls to
+        methods and attributes, and *their* methods and attributes:
+
+        .. doctest::
+
+            >>> mock = Mock()
+            >>> mock.method()
+            <Mock name='mock.method()' id='...'>
+            >>> mock.property.method.attribute()
+            <Mock name='mock.property.method.attribute()' id='...'>
+            >>> mock.method_calls
+            [call.method(), call.property.method.attribute()]
+
+        Members of `method_calls` are :data:`call` objects. These can be
+        unpacked as tuples to get at the individual arguments. See
+        :ref:`calls as tuples <calls-as-tuples>`.
+
+
+    .. attribute:: mock_calls
+
+        `mock_calls` records *all* calls to the mock object, its methods, magic
+        methods *and* return value mocks.
+
+        .. doctest::
+
+            >>> mock = MagicMock()
+            >>> result = mock(1, 2, 3)
+            >>> mock.first(a=3)
+            <MagicMock name='mock.first()' id='...'>
+            >>> mock.second()
+            <MagicMock name='mock.second()' id='...'>
+            >>> int(mock)
+            1
+            >>> result(1)
+            <MagicMock name='mock()()' id='...'>
+            >>> expected = [call(1, 2, 3), call.first(a=3), call.second(),
+            ... call.__int__(), call()(1)]
+            >>> mock.mock_calls == expected
+            True
+
+        Members of `mock_calls` are :data:`call` objects. These can be
+        unpacked as tuples to get at the individual arguments. See
+        :ref:`calls as tuples <calls-as-tuples>`.
+
+
+    .. attribute:: __class__
+
+        Normally the `__class__` attribute of an object will return its type.
+        For a mock object with a `spec` `__class__` returns the spec class
+        instead. This allows mock objects to pass `isinstance` tests for the
+        object they are replacing / masquerading as:
+
+        .. doctest::
+
+            >>> mock = Mock(spec=3)
+            >>> isinstance(mock, int)
+            True
+
+        `__class__` is assignable to, this allows a mock to pass an
+        `isinstance` check without forcing you to use a spec:
+
+        .. doctest::
+
+            >>> mock = Mock()
+            >>> mock.__class__ = dict
+            >>> isinstance(mock, dict)
+            True
+
+.. class:: NonCallableMock(spec=None, wraps=None, name=None, spec_set=None, **kwargs)
+
+    A non-callable version of `Mock`. The constructor parameters have the same
+    meaning of `Mock`, with the exception of `return_value` and `side_effect`
+    which have no meaning on a non-callable mock.
+
+Mock objects that use a class or an instance as a `spec` or `spec_set` are able
+to pass `isintance` tests:
+
+.. doctest::
+
+    >>> mock = Mock(spec=SomeClass)
+    >>> isinstance(mock, SomeClass)
+    True
+    >>> mock = Mock(spec_set=SomeClass())
+    >>> isinstance(mock, SomeClass)
+    True
+
+The `Mock` classes have support for mocking magic methods. See :ref:`magic
+methods <magic-methods>` for the full details.
+
+The mock classes and the :func:`patch` decorators all take arbitrary keyword
+arguments for configuration. For the `patch` decorators the keywords are
+passed to the constructor of the mock being created. The keyword arguments
+are for configuring attributes of the mock:
+
+.. doctest::
+
+        >>> m = MagicMock(attribute=3, other='fish')
+        >>> m.attribute
+        3
+        >>> m.other
+        'fish'
+
+The return value and side effect of child mocks can be set in the same way,
+using dotted notation. As you can't use dotted names directly in a call you
+have to create a dictionary and unpack it using `**`:
+
+.. doctest::
+
+    >>> attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
+    >>> mock = Mock(some_attribute='eggs', **attrs)
+    >>> mock.some_attribute
+    'eggs'
+    >>> mock.method()
+    3
+    >>> mock.other()
+    Traceback (most recent call last):
+      ...
+    KeyError
+
+
+.. class:: PropertyMock(*args, **kwargs)
+
+   A mock intended to be used as a property, or other descriptor, on a class.
+   `PropertyMock` provides `__get__` and `__set__` methods so you can specify
+   a return value when it is fetched.
+
+   Fetching a `PropertyMock` instance from an object calls the mock, with
+   no args. Setting it calls the mock with the value being set.
+
+   .. doctest::
+
+        >>> class Foo(object):
+        ...     @property
+        ...     def foo(self):
+        ...         return 'something'
+        ...     @foo.setter
+        ...     def foo(self, value):
+        ...         pass
+        ...
+        >>> with patch('__main__.Foo.foo', new_callable=PropertyMock) as mock_foo:
+        ...     mock_foo.return_value = 'mockity-mock'
+        ...     this_foo = Foo()
+        ...     print this_foo.foo
+        ...     this_foo.foo = 6
+        ...
+        mockity-mock
+        >>> mock_foo.mock_calls
+        [call(), call(6)]
+
+Because of the way mock attributes are stored you can't directly attach a
+`PropertyMock` to a mock object. Instead you can attach it to the mock type
+object:
+
+.. doctest::
+
+    >>> m = MagicMock()
+    >>> p = PropertyMock(return_value=3)
+    >>> type(m).foo = p
+    >>> m.foo
+    3
+    >>> p.assert_called_once_with()
+
+
+.. index:: __call__
+.. index:: calling
+
+Calling
+=======
+
+Mock objects are callable. The call will return the value set as the
+:attr:`~Mock.return_value` attribute. The default return value is a new Mock
+object; it is created the first time the return value is accessed (either
+explicitly or by calling the Mock) - but it is stored and the same one
+returned each time.
+
+Calls made to the object will be recorded in the attributes
+like :attr:`~Mock.call_args` and :attr:`~Mock.call_args_list`.
+
+If :attr:`~Mock.side_effect` is set then it will be called after the call has
+been recorded, so if `side_effect` raises an exception the call is still
+recorded.
+
+The simplest way to make a mock raise an exception when called is to make
+:attr:`~Mock.side_effect` an exception class or instance:
+
+.. doctest::
+
+        >>> m = MagicMock(side_effect=IndexError)
+        >>> m(1, 2, 3)
+        Traceback (most recent call last):
+          ...
+        IndexError
+        >>> m.mock_calls
+        [call(1, 2, 3)]
+        >>> m.side_effect = KeyError('Bang!')
+        >>> m('two', 'three', 'four')
+        Traceback (most recent call last):
+          ...
+        KeyError: 'Bang!'
+        >>> m.mock_calls
+        [call(1, 2, 3), call('two', 'three', 'four')]
+
+If `side_effect` is a function then whatever that function returns is what
+calls to the mock return. The `side_effect` function is called with the
+same arguments as the mock. This allows you to vary the return value of the
+call dynamically, based on the input:
+
+.. doctest::
+
+        >>> def side_effect(value):
+        ...     return value + 1
+        ...
+        >>> m = MagicMock(side_effect=side_effect)
+        >>> m(1)
+        2
+        >>> m(2)
+        3
+        >>> m.mock_calls
+        [call(1), call(2)]
+
+If you want the mock to still return the default return value (a new mock), or
+any set return value, then there are two ways of doing this. Either return
+`mock.return_value` from inside `side_effect`, or return :data:`DEFAULT`:
+
+.. doctest::
+
+        >>> m = MagicMock()
+        >>> def side_effect(*args, **kwargs):
+        ...     return m.return_value
+        ...
+        >>> m.side_effect = side_effect
+        >>> m.return_value = 3
+        >>> m()
+        3
+        >>> def side_effect(*args, **kwargs):
+        ...     return DEFAULT
+        ...
+        >>> m.side_effect = side_effect
+        >>> m()
+        3
+
+To remove a `side_effect`, and return to the default behaviour, set the
+`side_effect` to `None`:
+
+.. doctest::
+
+        >>> m = MagicMock(return_value=6)
+        >>> def side_effect(*args, **kwargs):
+        ...     return 3
+        ...
+        >>> m.side_effect = side_effect
+        >>> m()
+        3
+        >>> m.side_effect = None
+        >>> m()
+        6
+
+The `side_effect` can also be any iterable object. Repeated calls to the mock
+will return values from the iterable (until the iterable is exhausted and
+a `StopIteration` is raised):
+
+.. doctest::
+
+        >>> m = MagicMock(side_effect=[1, 2, 3])
+        >>> m()
+        1
+        >>> m()
+        2
+        >>> m()
+        3
+        >>> m()
+        Traceback (most recent call last):
+          ...
+        StopIteration
+
+If any members of the iterable are exceptions they will be raised instead of
+returned:
+
+.. doctest::
+
+        >>> iterable = (33, ValueError, 66)
+        >>> m = MagicMock(side_effect=iterable)
+        >>> m()
+        33
+        >>> m()
+        Traceback (most recent call last):
+         ...
+        ValueError
+        >>> m()
+        66
+
+
+.. _deleting-attributes:
+
+Deleting Attributes
+===================
+
+Mock objects create attributes on demand. This allows them to pretend to be
+objects of any type.
+
+You may want a mock object to return `False` to a `hasattr` call, or raise an
+`AttributeError` when an attribute is fetched. You can do this by providing
+an object as a `spec` for a mock, but that isn't always convenient.
+
+You "block" attributes by deleting them. Once deleted, accessing an attribute
+will raise an `AttributeError`.
+
+.. doctest::
+
+    >>> mock = MagicMock()
+    >>> hasattr(mock, 'm')
+    True
+    >>> del mock.m
+    >>> hasattr(mock, 'm')
+    False
+    >>> del mock.f
+    >>> mock.f
+    Traceback (most recent call last):
+        ...
+    AttributeError: f
+
+
+Attaching Mocks as Attributes
+=============================
+
+When you attach a mock as an attribute of another mock (or as the return
+value) it becomes a "child" of that mock. Calls to the child are recorded in
+the :attr:`~Mock.method_calls` and :attr:`~Mock.mock_calls` attributes of the
+parent. This is useful for configuring child mocks and then attaching them to
+the parent, or for attaching mocks to a parent that records all calls to the
+children and allows you to make assertions about the order of calls between
+mocks:
+
+.. doctest::
+
+    >>> parent = MagicMock()
+    >>> child1 = MagicMock(return_value=None)
+    >>> child2 = MagicMock(return_value=None)
+    >>> parent.child1 = child1
+    >>> parent.child2 = child2
+    >>> child1(1)
+    >>> child2(2)
+    >>> parent.mock_calls
+    [call.child1(1), call.child2(2)]
+
+The exception to this is if the mock has a name. This allows you to prevent
+the "parenting" if for some reason you don't want it to happen.
+
+.. doctest::
+
+    >>> mock = MagicMock()
+    >>> not_a_child = MagicMock(name='not-a-child')
+    >>> mock.attribute = not_a_child
+    >>> mock.attribute()
+    <MagicMock name='not-a-child()' id='...'>
+    >>> mock.mock_calls
+    []
+
+Mocks created for you by :func:`patch` are automatically given names. To
+attach mocks that have names to a parent you use the :meth:`~Mock.attach_mock`
+method:
+
+.. doctest::
+
+    >>> thing1 = object()
+    >>> thing2 = object()
+    >>> parent = MagicMock()
+    >>> with patch('__main__.thing1', return_value=None) as child1:
+    ...     with patch('__main__.thing2', return_value=None) as child2:
+    ...         parent.attach_mock(child1, 'child1')
+    ...         parent.attach_mock(child2, 'child2')
+    ...         child1('one')
+    ...         child2('two')
+    ...
+    >>> parent.mock_calls
+    [call.child1('one'), call.child2('two')]
+
+
+-----
+
+.. [#] The only exceptions are magic methods and attributes (those that have
+       leading and trailing double underscores). Mock doesn't create these but
+       instead of raises an ``AttributeError``. This is because the interpreter
+       will often implicitly request these methods, and gets *very* confused to
+       get a new Mock object when it expects a magic method. If you need magic
+       method support see :ref:`magic methods <magic-methods>`.

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/patch.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/patch.txt
@@ -1,0 +1,636 @@
+==================
+ Patch Decorators
+==================
+
+
+.. currentmodule:: mock
+
+.. testsetup::
+
+    class SomeClass(object):
+        static_method = None
+        class_method = None
+        attribute = None
+
+    sys.modules['package'] = package = Mock(name='package')
+    sys.modules['package.module'] = package.module
+
+    class TestCase(unittest2.TestCase):
+        def run(self):
+            result = unittest2.TestResult()
+            super(unittest2.TestCase, self).run(result)
+            assert result.wasSuccessful()
+
+.. testcleanup::
+
+    patch.TEST_PREFIX = 'test'
+
+
+The patch decorators are used for patching objects only within the scope of
+the function they decorate. They automatically handle the unpatching for you,
+even if exceptions are raised. All of these functions can also be used in with
+statements or as class decorators.
+
+
+patch
+=====
+
+.. note::
+
+    `patch` is straightforward to use. The key is to do the patching in the
+    right namespace. See the section `where to patch`_.
+
+.. function:: patch(target, new=DEFAULT, spec=None, create=False, spec_set=None, autospec=None, new_callable=None, **kwargs)
+
+    `patch` acts as a function decorator, class decorator or a context
+    manager. Inside the body of the function or with statement, the `target`
+    is patched with a `new` object. When the function/with statement exits
+    the patch is undone.
+
+    If `new` is omitted, then the target is replaced with a
+    :class:`MagicMock`. If `patch` is used as a decorator and `new` is
+    omitted, the created mock is passed in as an extra argument to the
+    decorated function. If `patch` is used as a context manager the created
+    mock is returned by the context manager.
+
+    `target` should be a string in the form `'package.module.ClassName'`. The
+    `target` is imported and the specified object replaced with the `new`
+    object, so the `target` must be importable from the environment you are
+    calling `patch` from. The target is imported when the decorated function
+    is executed, not at decoration time.
+
+    The `spec` and `spec_set` keyword arguments are passed to the `MagicMock`
+    if patch is creating one for you.
+
+    In addition you can pass `spec=True` or `spec_set=True`, which causes
+    patch to pass in the object being mocked as the spec/spec_set object.
+
+    `new_callable` allows you to specify a different class, or callable object,
+    that will be called to create the `new` object. By default `MagicMock` is
+    used.
+
+    A more powerful form of `spec` is `autospec`. If you set `autospec=True`
+    then the mock with be created with a spec from the object being replaced.
+    All attributes of the mock will also have the spec of the corresponding
+    attribute of the object being replaced. Methods and functions being mocked
+    will have their arguments checked and will raise a `TypeError` if they are
+    called with the wrong signature. For mocks
+    replacing a class, their return value (the 'instance') will have the same
+    spec as the class. See the :func:`create_autospec` function and
+    :ref:`auto-speccing`.
+
+    Instead of `autospec=True` you can pass `autospec=some_object` to use an
+    arbitrary object as the spec instead of the one being replaced.
+
+    By default `patch` will fail to replace attributes that don't exist. If
+    you pass in `create=True`, and the attribute doesn't exist, patch will
+    create the attribute for you when the patched function is called, and
+    delete it again afterwards. This is useful for writing tests against
+    attributes that your production code creates at runtime. It is off by by
+    default because it can be dangerous. With it switched on you can write
+    passing tests against APIs that don't actually exist!
+
+    Patch can be used as a `TestCase` class decorator. It works by
+    decorating each test method in the class. This reduces the boilerplate
+    code when your test methods share a common patchings set. `patch` finds
+    tests by looking for method names that start with `patch.TEST_PREFIX`.
+    By default this is `test`, which matches the way `unittest` finds tests.
+    You can specify an alternative prefix by setting `patch.TEST_PREFIX`.
+
+    Patch can be used as a context manager, with the with statement. Here the
+    patching applies to the indented block after the with statement. If you
+    use "as" then the patched object will be bound to the name after the
+    "as"; very useful if `patch` is creating a mock object for you.
+
+    `patch` takes arbitrary keyword arguments. These will be passed to
+    the `Mock` (or `new_callable`) on construction.
+
+    `patch.dict(...)`, `patch.multiple(...)` and `patch.object(...)` are
+    available for alternate use-cases.
+
+`patch` as function decorator, creating the mock for you and passing it into
+the decorated function:
+
+.. doctest::
+
+    >>> @patch('__main__.SomeClass')
+    ... def function(normal_argument, mock_class):
+    ...     print mock_class is SomeClass
+    ...
+    >>> function(None)
+    True
+
+
+Patching a class replaces the class with a `MagicMock` *instance*. If the
+class is instantiated in the code under test then it will be the
+:attr:`~Mock.return_value` of the mock that will be used.
+
+If the class is instantiated multiple times you could use
+:attr:`~Mock.side_effect` to return a new mock each time. Alternatively you
+can set the `return_value` to be anything you want.
+
+To configure return values on methods of *instances* on the patched class
+you must do this on the `return_value`. For example:
+
+.. doctest::
+
+    >>> class Class(object):
+    ...     def method(self):
+    ...         pass
+    ...
+    >>> with patch('__main__.Class') as MockClass:
+    ...     instance = MockClass.return_value
+    ...     instance.method.return_value = 'foo'
+    ...     assert Class() is instance
+    ...     assert Class().method() == 'foo'
+    ...
+
+If you use `spec` or `spec_set` and `patch` is replacing a *class*, then the
+return value of the created mock will have the same spec.
+
+.. doctest::
+
+    >>> Original = Class
+    >>> patcher = patch('__main__.Class', spec=True)
+    >>> MockClass = patcher.start()
+    >>> instance = MockClass()
+    >>> assert isinstance(instance, Original)
+    >>> patcher.stop()
+
+The `new_callable` argument is useful where you want to use an alternative
+class to the default :class:`MagicMock` for the created mock. For example, if
+you wanted a :class:`NonCallableMock` to be used:
+
+.. doctest::
+
+    >>> thing = object()
+    >>> with patch('__main__.thing', new_callable=NonCallableMock) as mock_thing:
+    ...     assert thing is mock_thing
+    ...     thing()
+    ...
+    Traceback (most recent call last):
+      ...
+    TypeError: 'NonCallableMock' object is not callable
+
+Another use case might be to replace an object with a `StringIO` instance:
+
+.. doctest::
+
+    >>> from StringIO import StringIO
+    >>> def foo():
+    ...     print 'Something'
+    ...
+    >>> @patch('sys.stdout', new_callable=StringIO)
+    ... def test(mock_stdout):
+    ...     foo()
+    ...     assert mock_stdout.getvalue() == 'Something\n'
+    ...
+    >>> test()
+
+When `patch` is creating a mock for you, it is common that the first thing
+you need to do is to configure the mock. Some of that configuration can be done
+in the call to patch. Any arbitrary keywords you pass into the call will be
+used to set attributes on the created mock:
+
+.. doctest::
+
+    >>> patcher = patch('__main__.thing', first='one', second='two')
+    >>> mock_thing = patcher.start()
+    >>> mock_thing.first
+    'one'
+    >>> mock_thing.second
+    'two'
+
+As well as attributes on the created mock attributes, like the
+:attr:`~Mock.return_value` and :attr:`~Mock.side_effect`, of child mocks can
+also be configured. These aren't syntactically valid to pass in directly as
+keyword arguments, but a dictionary with these as keys can still be expanded
+into a `patch` call using `**`:
+
+.. doctest::
+
+    >>> config = {'method.return_value': 3, 'other.side_effect': KeyError}
+    >>> patcher = patch('__main__.thing', **config)
+    >>> mock_thing = patcher.start()
+    >>> mock_thing.method()
+    3
+    >>> mock_thing.other()
+    Traceback (most recent call last):
+      ...
+    KeyError
+
+
+patch.object
+============
+
+.. function:: patch.object(target, attribute, new=DEFAULT, spec=None, create=False, spec_set=None, autospec=None, new_callable=None, **kwargs)
+
+    patch the named member (`attribute`) on an object (`target`) with a mock
+    object.
+
+    `patch.object` can be used as a decorator, class decorator or a context
+    manager. Arguments `new`, `spec`, `create`, `spec_set`, `autospec` and
+    `new_callable` have the same meaning as for `patch`. Like `patch`,
+    `patch.object` takes arbitrary keyword arguments for configuring the mock
+    object it creates.
+
+    When used as a class decorator `patch.object` honours `patch.TEST_PREFIX`
+    for choosing which methods to wrap.
+
+You can either call `patch.object` with three arguments or two arguments. The
+three argument form takes the object to be patched, the attribute name and the
+object to replace the attribute with.
+
+When calling with the two argument form you omit the replacement object, and a
+mock is created for you and passed in as an extra argument to the decorated
+function:
+
+.. doctest::
+
+    >>> @patch.object(SomeClass, 'class_method')
+    ... def test(mock_method):
+    ...     SomeClass.class_method(3)
+    ...     mock_method.assert_called_with(3)
+    ...
+    >>> test()
+
+`spec`, `create` and the other arguments to `patch.object` have the same
+meaning as they do for `patch`.
+
+
+patch.dict
+==========
+
+.. function:: patch.dict(in_dict, values=(), clear=False, **kwargs)
+
+    Patch a dictionary, or dictionary like object, and restore the dictionary
+    to its original state after the test.
+
+    `in_dict` can be a dictionary or a mapping like container. If it is a
+    mapping then it must at least support getting, setting and deleting items
+    plus iterating over keys.
+
+    `in_dict` can also be a string specifying the name of the dictionary, which
+    will then be fetched by importing it.
+
+    `values` can be a dictionary of values to set in the dictionary. `values`
+    can also be an iterable of `(key, value)` pairs.
+
+    If `clear` is True then the dictionary will be cleared before the new
+    values are set.
+
+    `patch.dict` can also be called with arbitrary keyword arguments to set
+    values in the dictionary.
+
+    `patch.dict` can be used as a context manager, decorator or class
+    decorator. When used as a class decorator `patch.dict` honours
+    `patch.TEST_PREFIX` for choosing which methods to wrap.
+
+`patch.dict` can be used to add members to a dictionary, or simply let a test
+change a dictionary, and ensure the dictionary is restored when the test
+ends.
+
+.. doctest::
+
+    >>> from mock import patch
+    >>> foo = {}
+    >>> with patch.dict(foo, {'newkey': 'newvalue'}):
+    ...     assert foo == {'newkey': 'newvalue'}
+    ...
+    >>> assert foo == {}
+
+    >>> import os
+    >>> with patch.dict('os.environ', {'newkey': 'newvalue'}):
+    ...     print os.environ['newkey']
+    ...
+    newvalue
+    >>> assert 'newkey' not in os.environ
+
+Keywords can be used in the `patch.dict` call to set values in the dictionary:
+
+.. doctest::
+
+    >>> mymodule = MagicMock()
+    >>> mymodule.function.return_value = 'fish'
+    >>> with patch.dict('sys.modules', mymodule=mymodule):
+    ...     import mymodule
+    ...     mymodule.function('some', 'args')
+    ...
+    'fish'
+
+`patch.dict` can be used with dictionary like objects that aren't actually
+dictionaries. At the very minimum they must support item getting, setting,
+deleting and either iteration or membership test. This corresponds to the
+magic methods `__getitem__`, `__setitem__`, `__delitem__` and either
+`__iter__` or `__contains__`.
+
+.. doctest::
+
+    >>> class Container(object):
+    ...     def __init__(self):
+    ...         self.values = {}
+    ...     def __getitem__(self, name):
+    ...         return self.values[name]
+    ...     def __setitem__(self, name, value):
+    ...         self.values[name] = value
+    ...     def __delitem__(self, name):
+    ...         del self.values[name]
+    ...     def __iter__(self):
+    ...         return iter(self.values)
+    ...
+    >>> thing = Container()
+    >>> thing['one'] = 1
+    >>> with patch.dict(thing, one=2, two=3):
+    ...     assert thing['one'] == 2
+    ...     assert thing['two'] == 3
+    ...
+    >>> assert thing['one'] == 1
+    >>> assert list(thing) == ['one']
+
+
+patch.multiple
+==============
+
+.. function:: patch.multiple(target, spec=None, create=False, spec_set=None, autospec=None, new_callable=None, **kwargs)
+
+    Perform multiple patches in a single call. It takes the object to be
+    patched (either as an object or a string to fetch the object by importing)
+    and keyword arguments for the patches::
+
+        with patch.multiple(settings, FIRST_PATCH='one', SECOND_PATCH='two'):
+            ...
+
+    Use :data:`DEFAULT` as the value if you want `patch.multiple` to create
+    mocks for you. In this case the created mocks are passed into a decorated
+    function by keyword, and a dictionary is returned when `patch.multiple` is
+    used as a context manager.
+
+    `patch.multiple` can be used as a decorator, class decorator or a context
+    manager. The arguments `spec`, `spec_set`, `create`, `autospec` and
+    `new_callable` have the same meaning as for `patch`. These arguments will
+    be applied to *all* patches done by `patch.multiple`.
+
+    When used as a class decorator `patch.multiple` honours `patch.TEST_PREFIX`
+    for choosing which methods to wrap.
+
+If you want `patch.multiple` to create mocks for you, then you can use
+:data:`DEFAULT` as the value. If you use `patch.multiple` as a decorator
+then the created mocks are passed into the decorated function by keyword.
+
+.. doctest::
+
+    >>> thing = object()
+    >>> other = object()
+
+    >>> @patch.multiple('__main__', thing=DEFAULT, other=DEFAULT)
+    ... def test_function(thing, other):
+    ...     assert isinstance(thing, MagicMock)
+    ...     assert isinstance(other, MagicMock)
+    ...
+    >>> test_function()
+
+`patch.multiple` can be nested with other `patch` decorators, but put arguments
+passed by keyword *after* any of the standard arguments created by `patch`:
+
+.. doctest::
+
+    >>> @patch('sys.exit')
+    ... @patch.multiple('__main__', thing=DEFAULT, other=DEFAULT)
+    ... def test_function(mock_exit, other, thing):
+    ...     assert 'other' in repr(other)
+    ...     assert 'thing' in repr(thing)
+    ...     assert 'exit' in repr(mock_exit)
+    ...
+    >>> test_function()
+
+If `patch.multiple` is used as a context manager, the value returned by the
+context manger is a dictionary where created mocks are keyed by name:
+
+.. doctest::
+
+    >>> with patch.multiple('__main__', thing=DEFAULT, other=DEFAULT) as values:
+    ...     assert 'other' in repr(values['other'])
+    ...     assert 'thing' in repr(values['thing'])
+    ...     assert values['thing'] is thing
+    ...     assert values['other'] is other
+    ...
+
+
+.. _start-and-stop:
+
+patch methods: start and stop
+=============================
+
+All the patchers have `start` and `stop` methods. These make it simpler to do
+patching in `setUp` methods or where you want to do multiple patches without
+nesting decorators or with statements.
+
+To use them call `patch`, `patch.object` or `patch.dict` as normal and keep a
+reference to the returned `patcher` object. You can then call `start` to put
+the patch in place and `stop` to undo it.
+
+If you are using `patch` to create a mock for you then it will be returned by
+the call to `patcher.start`.
+
+.. doctest::
+
+    >>> patcher = patch('package.module.ClassName')
+    >>> from package import module
+    >>> original = module.ClassName
+    >>> new_mock = patcher.start()
+    >>> assert module.ClassName is not original
+    >>> assert module.ClassName is new_mock
+    >>> patcher.stop()
+    >>> assert module.ClassName is original
+    >>> assert module.ClassName is not new_mock
+
+
+A typical use case for this might be for doing multiple patches in the `setUp`
+method of a `TestCase`:
+
+.. doctest::
+
+    >>> class MyTest(TestCase):
+    ...     def setUp(self):
+    ...         self.patcher1 = patch('package.module.Class1')
+    ...         self.patcher2 = patch('package.module.Class2')
+    ...         self.MockClass1 = self.patcher1.start()
+    ...         self.MockClass2 = self.patcher2.start()
+    ...
+    ...     def tearDown(self):
+    ...         self.patcher1.stop()
+    ...         self.patcher2.stop()
+    ...
+    ...     def test_something(self):
+    ...         assert package.module.Class1 is self.MockClass1
+    ...         assert package.module.Class2 is self.MockClass2
+    ...
+    >>> MyTest('test_something').run()
+
+.. caution::
+
+    If you use this technique you must ensure that the patching is "undone" by
+    calling `stop`. This can be fiddlier than you might think, because if an
+    exception is raised in the setUp then tearDown is not called. `unittest2
+    <http://pypi.python.org/pypi/unittest2>`_ cleanup functions make this
+    easier.
+
+    .. doctest::
+
+        >>> class MyTest(TestCase):
+        ...     def setUp(self):
+        ...         patcher = patch('package.module.Class')
+        ...         self.MockClass = patcher.start()
+        ...         self.addCleanup(patcher.stop)
+        ...
+        ...     def test_something(self):
+        ...         assert package.module.Class is self.MockClass
+        ...
+        >>> MyTest('test_something').run()
+
+    As an added bonus you no longer need to keep a reference to the `patcher`
+    object.
+
+It is also possible to stop all patches which have been started by using
+`patch.stopall`.
+
+.. function:: patch.stopall
+
+    Stop all active patches. Only stops patches started with `start`.
+
+
+TEST_PREFIX
+===========
+
+All of the patchers can be used as class decorators. When used in this way
+they wrap every test method on the class. The patchers recognise methods that
+start with `test` as being test methods. This is the same way that the
+`unittest.TestLoader` finds test methods by default.
+
+It is possible that you want to use a different prefix for your tests. You can
+inform the patchers of the different prefix by setting `patch.TEST_PREFIX`:
+
+.. doctest::
+
+    >>> patch.TEST_PREFIX = 'foo'
+    >>> value = 3
+    >>>
+    >>> @patch('__main__.value', 'not three')
+    ... class Thing(object):
+    ...     def foo_one(self):
+    ...         print value
+    ...     def foo_two(self):
+    ...         print value
+    ...
+    >>>
+    >>> Thing().foo_one()
+    not three
+    >>> Thing().foo_two()
+    not three
+    >>> value
+    3
+
+
+Nesting Patch Decorators
+========================
+
+If you want to perform multiple patches then you can simply stack up the
+decorators.
+
+You can stack up multiple patch decorators using this pattern:
+
+.. doctest::
+
+    >>> @patch.object(SomeClass, 'class_method')
+    ... @patch.object(SomeClass, 'static_method')
+    ... def test(mock1, mock2):
+    ...     assert SomeClass.static_method is mock1
+    ...     assert SomeClass.class_method is mock2
+    ...     SomeClass.static_method('foo')
+    ...     SomeClass.class_method('bar')
+    ...     return mock1, mock2
+    ...
+    >>> mock1, mock2 = test()
+    >>> mock1.assert_called_once_with('foo')
+    >>> mock2.assert_called_once_with('bar')
+
+
+Note that the decorators are applied from the bottom upwards. This is the
+standard way that Python applies decorators. The order of the created mocks
+passed into your test function matches this order.
+
+Like all context-managers patches can be nested using contextlib's nested
+function; *every* patching will appear in the tuple after "as":
+
+.. doctest::
+
+    >>> from contextlib import nested
+    >>> with nested(
+    ...         patch('package.module.ClassName1'),
+    ...         patch('package.module.ClassName2')
+    ...     ) as (MockClass1, MockClass2):
+    ...     assert package.module.ClassName1 is MockClass1
+    ...     assert package.module.ClassName2 is MockClass2
+    ...
+
+
+.. _where-to-patch:
+
+Where to patch
+==============
+
+`patch` works by (temporarily) changing the object that a *name* points to with
+another one. There can be many names pointing to any individual object, so
+for patching to work you must ensure that you patch the name used by the system
+under test.
+
+The basic principle is that you patch where an object is *looked up*, which
+is not necessarily the same place as where it is defined. A couple of
+examples will help to clarify this.
+
+Imagine we have a project that we want to test with the following structure::
+
+    a.py
+        -> Defines SomeClass
+
+    b.py
+        -> from a import SomeClass
+        -> some_function instantiates SomeClass
+
+Now we want to test `some_function` but we want to mock out `SomeClass` using
+`patch`. The problem is that when we import module b, which we will have to
+do then it imports `SomeClass` from module a. If we use `patch` to mock out
+`a.SomeClass` then it will have no effect on our test; module b already has a
+reference to the *real* `SomeClass` and it looks like our patching had no
+effect.
+
+The key is to patch out `SomeClass` where it is used (or where it is looked up
+). In this case `some_function` will actually look up `SomeClass` in module b,
+where we have imported it. The patching should look like:
+
+    `@patch('b.SomeClass')`
+
+However, consider the alternative scenario where instead of `from a import
+SomeClass` module b does `import a` and `some_function` uses `a.SomeClass`. Both
+of these import forms are common. In this case the class we want to patch is
+being looked up on the a module and so we have to patch `a.SomeClass` instead:
+
+    `@patch('a.SomeClass')`
+
+
+Patching Descriptors and Proxy Objects
+======================================
+
+Since version 0.6.0 both patch_ and patch.object_ have been able to correctly
+patch and restore descriptors: class methods, static methods and properties.
+You should patch these on the *class* rather than an instance.
+
+Since version 0.7.0 patch_ and patch.object_ work correctly with some objects
+that proxy attribute access, like the `django setttings object
+<http://www.voidspace.org.uk/python/weblog/arch_d7_2010_12_04.shtml#e1198>`_.
+
+.. note::
+
+    In django `import settings` and `from django.conf import settings`
+    return different objects. If you are using libraries / apps that do both you
+    may have to patch both. Grrr...

--- a/ambari-metrics-host-monitoring/src/test/python/mock/docs/sentinel.txt
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/docs/sentinel.txt
@@ -1,0 +1,58 @@
+==========
+ Sentinel
+==========
+
+
+.. currentmodule:: mock
+
+.. testsetup::
+
+    class ProductionClass(object):
+        def something(self):
+            return self.method()
+
+    class Test(unittest2.TestCase):
+        def testSomething(self):
+            pass
+    self = Test('testSomething')
+
+
+.. data:: sentinel
+
+    The ``sentinel`` object provides a convenient way of providing unique
+    objects for your tests.
+
+    Attributes are created on demand when you access them by name. Accessing
+    the same attribute will always return the same object. The objects
+    returned have a sensible repr so that test failure messages are readable.
+
+
+.. data:: DEFAULT
+
+    The `DEFAULT` object is a pre-created sentinel (actually
+    `sentinel.DEFAULT`). It can be used by :attr:`~Mock.side_effect`
+    functions to indicate that the normal return value should be used.
+
+
+Sentinel Example
+================
+
+Sometimes when testing you need to test that a specific object is passed as an
+argument to another method, or returned. It can be common to create named
+sentinel objects to test this. `sentinel` provides a convenient way of
+creating and testing the identity of objects like this.
+
+In this example we monkey patch `method` to return
+`sentinel.some_object`:
+
+.. doctest::
+
+    >>> real = ProductionClass()
+    >>> real.method = Mock(name="method")
+    >>> real.method.return_value = sentinel.some_object
+    >>> result = real.method()
+    >>> assert result is sentinel.some_object
+    >>> sentinel.some_object
+    sentinel.some_object
+
+

--- a/ambari-metrics-host-monitoring/src/test/python/mock/extendmock.py
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/extendmock.py
@@ -1,0 +1,1 @@
+# merged into mock.py in Mock 0.7

--- a/ambari-metrics-host-monitoring/src/test/python/mock/mock.py
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/mock.py
@@ -1,0 +1,2365 @@
+# mock.py
+# Test tools for mocking and patching.
+# Copyright (C) 2007-2012 Michael Foord & the mock team
+# E-mail: fuzzyman AT voidspace DOT org DOT uk
+
+# mock 1.0.1
+# http://www.voidspace.org.uk/python/mock/
+
+# Released subject to the BSD License
+# Please see http://www.voidspace.org.uk/python/license.shtml
+
+__all__ = (
+    'Mock',
+    'MagicMock',
+    'patch',
+    'sentinel',
+    'DEFAULT',
+    'ANY',
+    'call',
+    'create_autospec',
+    'FILTER_DIR',
+    'NonCallableMock',
+    'NonCallableMagicMock',
+    'mock_open',
+    'PropertyMock',
+)
+
+
+__version__ = '1.0.1'
+
+
+import pprint
+import sys
+
+try:
+    import inspect
+except ImportError:
+    # for alternative platforms that
+    # may not have inspect
+    inspect = None
+
+try:
+    from functools import wraps as original_wraps
+except ImportError:
+    # Python 2.4 compatibility
+    def wraps(original):
+        def inner(f):
+            f.__name__ = original.__name__
+            f.__doc__ = original.__doc__
+            f.__module__ = original.__module__
+            wrapped = getattr(original, '__wrapped__', original)
+            f.__wrapped__ = wrapped
+            return f
+        return inner
+else:
+    if sys.version_info[:2] >= (3, 2):
+        wraps = original_wraps
+    else:
+        def wraps(func):
+            def inner(f):
+                f = original_wraps(func)(f)
+                wrapped = getattr(func, '__wrapped__', func)
+                f.__wrapped__ = wrapped
+                return f
+            return inner
+
+try:
+    unicode
+except NameError:
+    # Python 3
+    basestring = unicode = str
+
+try:
+    long
+except NameError:
+    # Python 3
+    long = int
+
+try:
+    BaseException
+except NameError:
+    # Python 2.4 compatibility
+    BaseException = Exception
+
+try:
+    next
+except NameError:
+    def next(obj):
+        return obj.next()
+
+
+BaseExceptions = (BaseException,)
+if 'java' in sys.platform:
+    # jython
+    import java
+    BaseExceptions = (BaseException, java.lang.Throwable)
+
+try:
+    _isidentifier = str.isidentifier
+except AttributeError:
+    # Python 2.X
+    import keyword
+    import re
+    regex = re.compile(r'^[a-z_][a-z0-9_]*$', re.I)
+    def _isidentifier(string):
+        if string in keyword.kwlist:
+            return False
+        return regex.match(string)
+
+
+inPy3k = sys.version_info[0] == 3
+
+# Needed to work around Python 3 bug where use of "super" interferes with
+# defining __class__ as a descriptor
+_super = super
+
+self = 'im_self'
+builtin = '__builtin__'
+if inPy3k:
+    self = '__self__'
+    builtin = 'builtins'
+
+FILTER_DIR = True
+
+
+def _is_instance_mock(obj):
+    # can't use isinstance on Mock objects because they override __class__
+    # The base class for all mocks is NonCallableMock
+    return issubclass(type(obj), NonCallableMock)
+
+
+def _is_exception(obj):
+    return (
+        isinstance(obj, BaseExceptions) or
+        isinstance(obj, ClassTypes) and issubclass(obj, BaseExceptions)
+    )
+
+
+class _slotted(object):
+    __slots__ = ['a']
+
+
+DescriptorTypes = (
+    type(_slotted.a),
+    property,
+)
+
+
+def _getsignature(func, skipfirst, instance=False):
+    if inspect is None:
+        raise ImportError('inspect module not available')
+
+    if isinstance(func, ClassTypes) and not instance:
+        try:
+            func = func.__init__
+        except AttributeError:
+            return
+        skipfirst = True
+    elif not isinstance(func, FunctionTypes):
+        # for classes where instance is True we end up here too
+        try:
+            func = func.__call__
+        except AttributeError:
+            return
+
+    if inPy3k:
+        try:
+            argspec = inspect.getfullargspec(func)
+        except TypeError:
+            # C function / method, possibly inherited object().__init__
+            return
+        regargs, varargs, varkw, defaults, kwonly, kwonlydef, ann = argspec
+    else:
+        try:
+            regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
+        except TypeError:
+            # C function / method, possibly inherited object().__init__
+            return
+
+    # instance methods and classmethods need to lose the self argument
+    if getattr(func, self, None) is not None:
+        regargs = regargs[1:]
+    if skipfirst:
+        # this condition and the above one are never both True - why?
+        regargs = regargs[1:]
+
+    if inPy3k:
+        signature = inspect.formatargspec(
+            regargs, varargs, varkw, defaults,
+            kwonly, kwonlydef, ann, formatvalue=lambda value: "")
+    else:
+        signature = inspect.formatargspec(
+            regargs, varargs, varkwargs, defaults,
+            formatvalue=lambda value: "")
+    return signature[1:-1], func
+
+
+def _check_signature(func, mock, skipfirst, instance=False):
+    if not _callable(func):
+        return
+
+    result = _getsignature(func, skipfirst, instance)
+    if result is None:
+        return
+    signature, func = result
+
+    # can't use self because "self" is common as an argument name
+    # unfortunately even not in the first place
+    src = "lambda _mock_self, %s: None" % signature
+    checksig = eval(src, {})
+    _copy_func_details(func, checksig)
+    type(mock)._mock_check_sig = checksig
+
+
+def _copy_func_details(func, funcopy):
+    funcopy.__name__ = func.__name__
+    funcopy.__doc__ = func.__doc__
+    #funcopy.__dict__.update(func.__dict__)
+    funcopy.__module__ = func.__module__
+    if not inPy3k:
+        funcopy.func_defaults = func.func_defaults
+        return
+    funcopy.__defaults__ = func.__defaults__
+    funcopy.__kwdefaults__ = func.__kwdefaults__
+
+
+def _callable(obj):
+    if isinstance(obj, ClassTypes):
+        return True
+    if getattr(obj, '__call__', None) is not None:
+        return True
+    return False
+
+
+def _is_list(obj):
+    # checks for list or tuples
+    # XXXX badly named!
+    return type(obj) in (list, tuple)
+
+
+def _instance_callable(obj):
+    """Given an object, return True if the object is callable.
+    For classes, return True if instances would be callable."""
+    if not isinstance(obj, ClassTypes):
+        # already an instance
+        return getattr(obj, '__call__', None) is not None
+
+    klass = obj
+    # uses __bases__ instead of __mro__ so that we work with old style classes
+    if klass.__dict__.get('__call__') is not None:
+        return True
+
+    for base in klass.__bases__:
+        if _instance_callable(base):
+            return True
+    return False
+
+
+def _set_signature(mock, original, instance=False):
+    # creates a function with signature (*args, **kwargs) that delegates to a
+    # mock. It still does signature checking by calling a lambda with the same
+    # signature as the original.
+    if not _callable(original):
+        return
+
+    skipfirst = isinstance(original, ClassTypes)
+    result = _getsignature(original, skipfirst, instance)
+    if result is None:
+        # was a C function (e.g. object().__init__ ) that can't be mocked
+        return
+
+    signature, func = result
+
+    src = "lambda %s: None" % signature
+    checksig = eval(src, {})
+    _copy_func_details(func, checksig)
+
+    name = original.__name__
+    if not _isidentifier(name):
+        name = 'funcopy'
+    context = {'_checksig_': checksig, 'mock': mock}
+    src = """def %s(*args, **kwargs):
+    _checksig_(*args, **kwargs)
+    return mock(*args, **kwargs)""" % name
+    exec (src, context)
+    funcopy = context[name]
+    _setup_func(funcopy, mock)
+    return funcopy
+
+
+def _setup_func(funcopy, mock):
+    funcopy.mock = mock
+
+    # can't use isinstance with mocks
+    if not _is_instance_mock(mock):
+        return
+
+    def assert_called_with(*args, **kwargs):
+        return mock.assert_called_with(*args, **kwargs)
+    def assert_called_once_with(*args, **kwargs):
+        return mock.assert_called_once_with(*args, **kwargs)
+    def assert_has_calls(*args, **kwargs):
+        return mock.assert_has_calls(*args, **kwargs)
+    def assert_any_call(*args, **kwargs):
+        return mock.assert_any_call(*args, **kwargs)
+    def reset_mock():
+        funcopy.method_calls = _CallList()
+        funcopy.mock_calls = _CallList()
+        mock.reset_mock()
+        ret = funcopy.return_value
+        if _is_instance_mock(ret) and not ret is mock:
+            ret.reset_mock()
+
+    funcopy.called = False
+    funcopy.call_count = 0
+    funcopy.call_args = None
+    funcopy.call_args_list = _CallList()
+    funcopy.method_calls = _CallList()
+    funcopy.mock_calls = _CallList()
+
+    funcopy.return_value = mock.return_value
+    funcopy.side_effect = mock.side_effect
+    funcopy._mock_children = mock._mock_children
+
+    funcopy.assert_called_with = assert_called_with
+    funcopy.assert_called_once_with = assert_called_once_with
+    funcopy.assert_has_calls = assert_has_calls
+    funcopy.assert_any_call = assert_any_call
+    funcopy.reset_mock = reset_mock
+
+    mock._mock_delegate = funcopy
+
+
+def _is_magic(name):
+    return '__%s__' % name[2:-2] == name
+
+
+class _SentinelObject(object):
+    "A unique, named, sentinel object."
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return 'sentinel.%s' % self.name
+
+
+class _Sentinel(object):
+    """Access attributes to return a named object, usable as a sentinel."""
+    def __init__(self):
+        self._sentinels = {}
+
+    def __getattr__(self, name):
+        if name == '__bases__':
+            # Without this help(mock) raises an exception
+            raise AttributeError
+        return self._sentinels.setdefault(name, _SentinelObject(name))
+
+
+sentinel = _Sentinel()
+
+DEFAULT = sentinel.DEFAULT
+_missing = sentinel.MISSING
+_deleted = sentinel.DELETED
+
+
+class OldStyleClass:
+    pass
+ClassType = type(OldStyleClass)
+
+
+def _copy(value):
+    if type(value) in (dict, list, tuple, set):
+        return type(value)(value)
+    return value
+
+
+ClassTypes = (type,)
+if not inPy3k:
+    ClassTypes = (type, ClassType)
+
+_allowed_names = set(
+    [
+        'return_value', '_mock_return_value', 'side_effect',
+        '_mock_side_effect', '_mock_parent', '_mock_new_parent',
+        '_mock_name', '_mock_new_name'
+    ]
+)
+
+
+def _delegating_property(name):
+    _allowed_names.add(name)
+    _the_name = '_mock_' + name
+    def _get(self, name=name, _the_name=_the_name):
+        sig = self._mock_delegate
+        if sig is None:
+            return getattr(self, _the_name)
+        return getattr(sig, name)
+    def _set(self, value, name=name, _the_name=_the_name):
+        sig = self._mock_delegate
+        if sig is None:
+            self.__dict__[_the_name] = value
+        else:
+            setattr(sig, name, value)
+
+    return property(_get, _set)
+
+
+
+class _CallList(list):
+
+    def __contains__(self, value):
+        if not isinstance(value, list):
+            return list.__contains__(self, value)
+        len_value = len(value)
+        len_self = len(self)
+        if len_value > len_self:
+            return False
+
+        for i in range(0, len_self - len_value + 1):
+            sub_list = self[i:i+len_value]
+            if sub_list == value:
+                return True
+        return False
+
+    def __repr__(self):
+        return pprint.pformat(list(self))
+
+
+def _check_and_set_parent(parent, value, name, new_name):
+    if not _is_instance_mock(value):
+        return False
+    if ((value._mock_name or value._mock_new_name) or
+        (value._mock_parent is not None) or
+        (value._mock_new_parent is not None)):
+        return False
+
+    _parent = parent
+    while _parent is not None:
+        # setting a mock (value) as a child or return value of itself
+        # should not modify the mock
+        if _parent is value:
+            return False
+        _parent = _parent._mock_new_parent
+
+    if new_name:
+        value._mock_new_parent = parent
+        value._mock_new_name = new_name
+    if name:
+        value._mock_parent = parent
+        value._mock_name = name
+    return True
+
+
+
+class Base(object):
+    _mock_return_value = DEFAULT
+    _mock_side_effect = None
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+
+class NonCallableMock(Base):
+    """A non-callable version of `Mock`"""
+
+    def __new__(cls, *args, **kw):
+        # every instance has its own class
+        # so we can create magic methods on the
+        # class without stomping on other mocks
+        new = type(cls.__name__, (cls,), {'__doc__': cls.__doc__})
+        instance = object.__new__(new)
+        return instance
+
+
+    def __init__(
+            self, spec=None, wraps=None, name=None, spec_set=None,
+            parent=None, _spec_state=None, _new_name='', _new_parent=None,
+            **kwargs
+        ):
+        if _new_parent is None:
+            _new_parent = parent
+
+        __dict__ = self.__dict__
+        __dict__['_mock_parent'] = parent
+        __dict__['_mock_name'] = name
+        __dict__['_mock_new_name'] = _new_name
+        __dict__['_mock_new_parent'] = _new_parent
+
+        if spec_set is not None:
+            spec = spec_set
+            spec_set = True
+
+        self._mock_add_spec(spec, spec_set)
+
+        __dict__['_mock_children'] = {}
+        __dict__['_mock_wraps'] = wraps
+        __dict__['_mock_delegate'] = None
+
+        __dict__['_mock_called'] = False
+        __dict__['_mock_call_args'] = None
+        __dict__['_mock_call_count'] = 0
+        __dict__['_mock_call_args_list'] = _CallList()
+        __dict__['_mock_mock_calls'] = _CallList()
+
+        __dict__['method_calls'] = _CallList()
+
+        if kwargs:
+            self.configure_mock(**kwargs)
+
+        _super(NonCallableMock, self).__init__(
+            spec, wraps, name, spec_set, parent,
+            _spec_state
+        )
+
+
+    def attach_mock(self, mock, attribute):
+        """
+        Attach a mock as an attribute of this one, replacing its name and
+        parent. Calls to the attached mock will be recorded in the
+        `method_calls` and `mock_calls` attributes of this one."""
+        mock._mock_parent = None
+        mock._mock_new_parent = None
+        mock._mock_name = ''
+        mock._mock_new_name = None
+
+        setattr(self, attribute, mock)
+
+
+    def mock_add_spec(self, spec, spec_set=False):
+        """Add a spec to a mock. `spec` can either be an object or a
+        list of strings. Only attributes on the `spec` can be fetched as
+        attributes from the mock.
+
+        If `spec_set` is True then only attributes on the spec can be set."""
+        self._mock_add_spec(spec, spec_set)
+
+
+    def _mock_add_spec(self, spec, spec_set):
+        _spec_class = None
+
+        if spec is not None and not _is_list(spec):
+            if isinstance(spec, ClassTypes):
+                _spec_class = spec
+            else:
+                _spec_class = _get_class(spec)
+
+            spec = dir(spec)
+
+        __dict__ = self.__dict__
+        __dict__['_spec_class'] = _spec_class
+        __dict__['_spec_set'] = spec_set
+        __dict__['_mock_methods'] = spec
+
+
+    def __get_return_value(self):
+        ret = self._mock_return_value
+        if self._mock_delegate is not None:
+            ret = self._mock_delegate.return_value
+
+        if ret is DEFAULT:
+            ret = self._get_child_mock(
+                _new_parent=self, _new_name='()'
+            )
+            self.return_value = ret
+        return ret
+
+
+    def __set_return_value(self, value):
+        if self._mock_delegate is not None:
+            self._mock_delegate.return_value = value
+        else:
+            self._mock_return_value = value
+            _check_and_set_parent(self, value, None, '()')
+
+    __return_value_doc = "The value to be returned when the mock is called."
+    return_value = property(__get_return_value, __set_return_value,
+                            __return_value_doc)
+
+
+    @property
+    def __class__(self):
+        if self._spec_class is None:
+            return type(self)
+        return self._spec_class
+
+    called = _delegating_property('called')
+    call_count = _delegating_property('call_count')
+    call_args = _delegating_property('call_args')
+    call_args_list = _delegating_property('call_args_list')
+    mock_calls = _delegating_property('mock_calls')
+
+
+    def __get_side_effect(self):
+        sig = self._mock_delegate
+        if sig is None:
+            return self._mock_side_effect
+        return sig.side_effect
+
+    def __set_side_effect(self, value):
+        value = _try_iter(value)
+        sig = self._mock_delegate
+        if sig is None:
+            self._mock_side_effect = value
+        else:
+            sig.side_effect = value
+
+    side_effect = property(__get_side_effect, __set_side_effect)
+
+
+    def reset_mock(self):
+        "Restore the mock object to its initial state."
+        self.called = False
+        self.call_args = None
+        self.call_count = 0
+        self.mock_calls = _CallList()
+        self.call_args_list = _CallList()
+        self.method_calls = _CallList()
+
+        for child in self._mock_children.values():
+            if isinstance(child, _SpecState):
+                continue
+            child.reset_mock()
+
+        ret = self._mock_return_value
+        if _is_instance_mock(ret) and ret is not self:
+            ret.reset_mock()
+
+
+    def configure_mock(self, **kwargs):
+        """Set attributes on the mock through keyword arguments.
+
+        Attributes plus return values and side effects can be set on child
+        mocks using standard dot notation and unpacking a dictionary in the
+        method call:
+
+        >>> attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
+        >>> mock.configure_mock(**attrs)"""
+        for arg, val in sorted(kwargs.items(),
+                               # we sort on the number of dots so that
+                               # attributes are set before we set attributes on
+                               # attributes
+                               key=lambda entry: entry[0].count('.')):
+            args = arg.split('.')
+            final = args.pop()
+            obj = self
+            for entry in args:
+                obj = getattr(obj, entry)
+            setattr(obj, final, val)
+
+
+    def __getattr__(self, name):
+        if name == '_mock_methods':
+            raise AttributeError(name)
+        elif self._mock_methods is not None:
+            if name not in self._mock_methods or name in _all_magics:
+                raise AttributeError("Mock object has no attribute %r" % name)
+        elif _is_magic(name):
+            raise AttributeError(name)
+
+        result = self._mock_children.get(name)
+        if result is _deleted:
+            raise AttributeError(name)
+        elif result is None:
+            wraps = None
+            if self._mock_wraps is not None:
+                # XXXX should we get the attribute without triggering code
+                # execution?
+                wraps = getattr(self._mock_wraps, name)
+
+            result = self._get_child_mock(
+                parent=self, name=name, wraps=wraps, _new_name=name,
+                _new_parent=self
+            )
+            self._mock_children[name]  = result
+
+        elif isinstance(result, _SpecState):
+            result = create_autospec(
+                result.spec, result.spec_set, result.instance,
+                result.parent, result.name
+            )
+            self._mock_children[name]  = result
+
+        return result
+
+
+    def __repr__(self):
+        _name_list = [self._mock_new_name]
+        _parent = self._mock_new_parent
+        last = self
+
+        dot = '.'
+        if _name_list == ['()']:
+            dot = ''
+        seen = set()
+        while _parent is not None:
+            last = _parent
+
+            _name_list.append(_parent._mock_new_name + dot)
+            dot = '.'
+            if _parent._mock_new_name == '()':
+                dot = ''
+
+            _parent = _parent._mock_new_parent
+
+            # use ids here so as not to call __hash__ on the mocks
+            if id(_parent) in seen:
+                break
+            seen.add(id(_parent))
+
+        _name_list = list(reversed(_name_list))
+        _first = last._mock_name or 'mock'
+        if len(_name_list) > 1:
+            if _name_list[1] not in ('()', '().'):
+                _first += '.'
+        _name_list[0] = _first
+        name = ''.join(_name_list)
+
+        name_string = ''
+        if name not in ('mock', 'mock.'):
+            name_string = ' name=%r' % name
+
+        spec_string = ''
+        if self._spec_class is not None:
+            spec_string = ' spec=%r'
+            if self._spec_set:
+                spec_string = ' spec_set=%r'
+            spec_string = spec_string % self._spec_class.__name__
+        return "<%s%s%s id='%s'>" % (
+            type(self).__name__,
+            name_string,
+            spec_string,
+            id(self)
+        )
+
+
+    def __dir__(self):
+        """Filter the output of `dir(mock)` to only useful members.
+        XXXX
+        """
+        extras = self._mock_methods or []
+        from_type = dir(type(self))
+        from_dict = list(self.__dict__)
+
+        if FILTER_DIR:
+            from_type = [e for e in from_type if not e.startswith('_')]
+            from_dict = [e for e in from_dict if not e.startswith('_') or
+                         _is_magic(e)]
+        return sorted(set(extras + from_type + from_dict +
+                          list(self._mock_children)))
+
+
+    def __setattr__(self, name, value):
+        if name in _allowed_names:
+            # property setters go through here
+            return object.__setattr__(self, name, value)
+        elif (self._spec_set and self._mock_methods is not None and
+            name not in self._mock_methods and
+            name not in self.__dict__):
+            raise AttributeError("Mock object has no attribute '%s'" % name)
+        elif name in _unsupported_magics:
+            msg = 'Attempting to set unsupported magic method %r.' % name
+            raise AttributeError(msg)
+        elif name in _all_magics:
+            if self._mock_methods is not None and name not in self._mock_methods:
+                raise AttributeError("Mock object has no attribute '%s'" % name)
+
+            if not _is_instance_mock(value):
+                setattr(type(self), name, _get_method(name, value))
+                original = value
+                value = lambda *args, **kw: original(self, *args, **kw)
+            else:
+                # only set _new_name and not name so that mock_calls is tracked
+                # but not method calls
+                _check_and_set_parent(self, value, None, name)
+                setattr(type(self), name, value)
+                self._mock_children[name] = value
+        elif name == '__class__':
+            self._spec_class = value
+            return
+        else:
+            if _check_and_set_parent(self, value, name, name):
+                self._mock_children[name] = value
+        return object.__setattr__(self, name, value)
+
+
+    def __delattr__(self, name):
+        if name in _all_magics and name in type(self).__dict__:
+            delattr(type(self), name)
+            if name not in self.__dict__:
+                # for magic methods that are still MagicProxy objects and
+                # not set on the instance itself
+                return
+
+        if name in self.__dict__:
+            object.__delattr__(self, name)
+
+        obj = self._mock_children.get(name, _missing)
+        if obj is _deleted:
+            raise AttributeError(name)
+        if obj is not _missing:
+            del self._mock_children[name]
+        self._mock_children[name] = _deleted
+
+
+
+    def _format_mock_call_signature(self, args, kwargs):
+        name = self._mock_name or 'mock'
+        return _format_call_signature(name, args, kwargs)
+
+
+    def _format_mock_failure_message(self, args, kwargs):
+        message = 'Expected call: %s\nActual call: %s'
+        expected_string = self._format_mock_call_signature(args, kwargs)
+        call_args = self.call_args
+        if len(call_args) == 3:
+            call_args = call_args[1:]
+        actual_string = self._format_mock_call_signature(*call_args)
+        return message % (expected_string, actual_string)
+
+
+    def assert_called_with(_mock_self, *args, **kwargs):
+        """assert that the mock was called with the specified arguments.
+
+        Raises an AssertionError if the args and keyword args passed in are
+        different to the last call to the mock."""
+        self = _mock_self
+        if self.call_args is None:
+            expected = self._format_mock_call_signature(args, kwargs)
+            raise AssertionError('Expected call: %s\nNot called' % (expected,))
+
+        if self.call_args != (args, kwargs):
+            msg = self._format_mock_failure_message(args, kwargs)
+            raise AssertionError(msg)
+
+
+    def assert_called_once_with(_mock_self, *args, **kwargs):
+        """assert that the mock was called exactly once and with the specified
+        arguments."""
+        self = _mock_self
+        if not self.call_count == 1:
+            msg = ("Expected to be called once. Called %s times." %
+                   self.call_count)
+            raise AssertionError(msg)
+        return self.assert_called_with(*args, **kwargs)
+
+
+    def assert_has_calls(self, calls, any_order=False):
+        """assert the mock has been called with the specified calls.
+        The `mock_calls` list is checked for the calls.
+
+        If `any_order` is False (the default) then the calls must be
+        sequential. There can be extra calls before or after the
+        specified calls.
+
+        If `any_order` is True then the calls can be in any order, but
+        they must all appear in `mock_calls`."""
+        if not any_order:
+            if calls not in self.mock_calls:
+                raise AssertionError(
+                    'Calls not found.\nExpected: %r\n'
+                    'Actual: %r' % (calls, self.mock_calls)
+                )
+            return
+
+        all_calls = list(self.mock_calls)
+
+        not_found = []
+        for kall in calls:
+            try:
+                all_calls.remove(kall)
+            except ValueError:
+                not_found.append(kall)
+        if not_found:
+            raise AssertionError(
+                '%r not all found in call list' % (tuple(not_found),)
+            )
+
+
+    def assert_any_call(self, *args, **kwargs):
+        """assert the mock has been called with the specified arguments.
+
+        The assert passes if the mock has *ever* been called, unlike
+        `assert_called_with` and `assert_called_once_with` that only pass if
+        the call is the most recent one."""
+        kall = call(*args, **kwargs)
+        if kall not in self.call_args_list:
+            expected_string = self._format_mock_call_signature(args, kwargs)
+            raise AssertionError(
+                '%s call not found' % expected_string
+            )
+
+
+    def _get_child_mock(self, **kw):
+        """Create the child mocks for attributes and return value.
+        By default child mocks will be the same type as the parent.
+        Subclasses of Mock may want to override this to customize the way
+        child mocks are made.
+
+        For non-callable mocks the callable variant will be used (rather than
+        any custom subclass)."""
+        _type = type(self)
+        if not issubclass(_type, CallableMixin):
+            if issubclass(_type, NonCallableMagicMock):
+                klass = MagicMock
+            elif issubclass(_type, NonCallableMock) :
+                klass = Mock
+        else:
+            klass = _type.__mro__[1]
+        return klass(**kw)
+
+
+
+def _try_iter(obj):
+    if obj is None:
+        return obj
+    if _is_exception(obj):
+        return obj
+    if _callable(obj):
+        return obj
+    try:
+        return iter(obj)
+    except TypeError:
+        # XXXX backwards compatibility
+        # but this will blow up on first call - so maybe we should fail early?
+        return obj
+
+
+
+class CallableMixin(Base):
+
+    def __init__(self, spec=None, side_effect=None, return_value=DEFAULT,
+                 wraps=None, name=None, spec_set=None, parent=None,
+                 _spec_state=None, _new_name='', _new_parent=None, **kwargs):
+        self.__dict__['_mock_return_value'] = return_value
+
+        _super(CallableMixin, self).__init__(
+            spec, wraps, name, spec_set, parent,
+            _spec_state, _new_name, _new_parent, **kwargs
+        )
+
+        self.side_effect = side_effect
+
+
+    def _mock_check_sig(self, *args, **kwargs):
+        # stub method that can be replaced with one with a specific signature
+        pass
+
+
+    def __call__(_mock_self, *args, **kwargs):
+        # can't use self in-case a function / method we are mocking uses self
+        # in the signature
+        _mock_self._mock_check_sig(*args, **kwargs)
+        return _mock_self._mock_call(*args, **kwargs)
+
+
+    def _mock_call(_mock_self, *args, **kwargs):
+        self = _mock_self
+        self.called = True
+        self.call_count += 1
+        self.call_args = _Call((args, kwargs), two=True)
+        self.call_args_list.append(_Call((args, kwargs), two=True))
+
+        _new_name = self._mock_new_name
+        _new_parent = self._mock_new_parent
+        self.mock_calls.append(_Call(('', args, kwargs)))
+
+        seen = set()
+        skip_next_dot = _new_name == '()'
+        do_method_calls = self._mock_parent is not None
+        name = self._mock_name
+        while _new_parent is not None:
+            this_mock_call = _Call((_new_name, args, kwargs))
+            if _new_parent._mock_new_name:
+                dot = '.'
+                if skip_next_dot:
+                    dot = ''
+
+                skip_next_dot = False
+                if _new_parent._mock_new_name == '()':
+                    skip_next_dot = True
+
+                _new_name = _new_parent._mock_new_name + dot + _new_name
+
+            if do_method_calls:
+                if _new_name == name:
+                    this_method_call = this_mock_call
+                else:
+                    this_method_call = _Call((name, args, kwargs))
+                _new_parent.method_calls.append(this_method_call)
+
+                do_method_calls = _new_parent._mock_parent is not None
+                if do_method_calls:
+                    name = _new_parent._mock_name + '.' + name
+
+            _new_parent.mock_calls.append(this_mock_call)
+            _new_parent = _new_parent._mock_new_parent
+
+            # use ids here so as not to call __hash__ on the mocks
+            _new_parent_id = id(_new_parent)
+            if _new_parent_id in seen:
+                break
+            seen.add(_new_parent_id)
+
+        ret_val = DEFAULT
+        effect = self.side_effect
+        if effect is not None:
+            if _is_exception(effect):
+                raise effect
+
+            if not _callable(effect):
+                result = next(effect)
+                if _is_exception(result):
+                    raise result
+                return result
+
+            ret_val = effect(*args, **kwargs)
+            if ret_val is DEFAULT:
+                ret_val = self.return_value
+
+        if (self._mock_wraps is not None and
+             self._mock_return_value is DEFAULT):
+            return self._mock_wraps(*args, **kwargs)
+        if ret_val is DEFAULT:
+            ret_val = self.return_value
+        return ret_val
+
+
+
+class Mock(CallableMixin, NonCallableMock):
+    """
+    Create a new `Mock` object. `Mock` takes several optional arguments
+    that specify the behaviour of the Mock object:
+
+    * `spec`: This can be either a list of strings or an existing object (a
+      class or instance) that acts as the specification for the mock object. If
+      you pass in an object then a list of strings is formed by calling dir on
+      the object (excluding unsupported magic attributes and methods). Accessing
+      any attribute not in this list will raise an `AttributeError`.
+
+      If `spec` is an object (rather than a list of strings) then
+      `mock.__class__` returns the class of the spec object. This allows mocks
+      to pass `isinstance` tests.
+
+    * `spec_set`: A stricter variant of `spec`. If used, attempting to *set*
+      or get an attribute on the mock that isn't on the object passed as
+      `spec_set` will raise an `AttributeError`.
+
+    * `side_effect`: A function to be called whenever the Mock is called. See
+      the `side_effect` attribute. Useful for raising exceptions or
+      dynamically changing return values. The function is called with the same
+      arguments as the mock, and unless it returns `DEFAULT`, the return
+      value of this function is used as the return value.
+
+      Alternatively `side_effect` can be an exception class or instance. In
+      this case the exception will be raised when the mock is called.
+
+      If `side_effect` is an iterable then each call to the mock will return
+      the next value from the iterable. If any of the members of the iterable
+      are exceptions they will be raised instead of returned.
+
+    * `return_value`: The value returned when the mock is called. By default
+      this is a new Mock (created on first access). See the
+      `return_value` attribute.
+
+    * `wraps`: Item for the mock object to wrap. If `wraps` is not None then
+      calling the Mock will pass the call through to the wrapped object
+      (returning the real result). Attribute access on the mock will return a
+      Mock object that wraps the corresponding attribute of the wrapped object
+      (so attempting to access an attribute that doesn't exist will raise an
+      `AttributeError`).
+
+      If the mock has an explicit `return_value` set then calls are not passed
+      to the wrapped object and the `return_value` is returned instead.
+
+    * `name`: If the mock has a name then it will be used in the repr of the
+      mock. This can be useful for debugging. The name is propagated to child
+      mocks.
+
+    Mocks can also be called with arbitrary keyword arguments. These will be
+    used to set attributes on the mock after it is created.
+    """
+
+
+
+def _dot_lookup(thing, comp, import_path):
+    try:
+        return getattr(thing, comp)
+    except AttributeError:
+        __import__(import_path)
+        return getattr(thing, comp)
+
+
+def _importer(target):
+    components = target.split('.')
+    import_path = components.pop(0)
+    thing = __import__(import_path)
+
+    for comp in components:
+        import_path += ".%s" % comp
+        thing = _dot_lookup(thing, comp, import_path)
+    return thing
+
+
+def _is_started(patcher):
+    # XXXX horrible
+    return hasattr(patcher, 'is_local')
+
+
+class _patch(object):
+
+    attribute_name = None
+    _active_patches = set()
+
+    def __init__(
+            self, getter, attribute, new, spec, create,
+            spec_set, autospec, new_callable, kwargs
+        ):
+        if new_callable is not None:
+            if new is not DEFAULT:
+                raise ValueError(
+                    "Cannot use 'new' and 'new_callable' together"
+                )
+            if autospec is not None:
+                raise ValueError(
+                    "Cannot use 'autospec' and 'new_callable' together"
+                )
+
+        self.getter = getter
+        self.attribute = attribute
+        self.new = new
+        self.new_callable = new_callable
+        self.spec = spec
+        self.create = create
+        self.has_local = False
+        self.spec_set = spec_set
+        self.autospec = autospec
+        self.kwargs = kwargs
+        self.additional_patchers = []
+
+
+    def copy(self):
+        patcher = _patch(
+            self.getter, self.attribute, self.new, self.spec,
+            self.create, self.spec_set,
+            self.autospec, self.new_callable, self.kwargs
+        )
+        patcher.attribute_name = self.attribute_name
+        patcher.additional_patchers = [
+            p.copy() for p in self.additional_patchers
+        ]
+        return patcher
+
+
+    def __call__(self, func):
+        if isinstance(func, ClassTypes):
+            return self.decorate_class(func)
+        return self.decorate_callable(func)
+
+
+    def decorate_class(self, klass):
+        for attr in dir(klass):
+            if not attr.startswith(patch.TEST_PREFIX):
+                continue
+
+            attr_value = getattr(klass, attr)
+            if not hasattr(attr_value, "__call__"):
+                continue
+
+            patcher = self.copy()
+            setattr(klass, attr, patcher(attr_value))
+        return klass
+
+
+    def decorate_callable(self, func):
+        if hasattr(func, 'patchings'):
+            func.patchings.append(self)
+            return func
+
+        @wraps(func)
+        def patched(*args, **keywargs):
+            # don't use a with here (backwards compatability with Python 2.4)
+            extra_args = []
+            entered_patchers = []
+
+            # can't use try...except...finally because of Python 2.4
+            # compatibility
+            exc_info = tuple()
+            try:
+                try:
+                    for patching in patched.patchings:
+                        arg = patching.__enter__()
+                        entered_patchers.append(patching)
+                        if patching.attribute_name is not None:
+                            keywargs.update(arg)
+                        elif patching.new is DEFAULT:
+                            extra_args.append(arg)
+
+                    args += tuple(extra_args)
+                    return func(*args, **keywargs)
+                except:
+                    if (patching not in entered_patchers and
+                        _is_started(patching)):
+                        # the patcher may have been started, but an exception
+                        # raised whilst entering one of its additional_patchers
+                        entered_patchers.append(patching)
+                    # Pass the exception to __exit__
+                    exc_info = sys.exc_info()
+                    # re-raise the exception
+                    raise
+            finally:
+                for patching in reversed(entered_patchers):
+                    patching.__exit__(*exc_info)
+
+        patched.patchings = [self]
+        if hasattr(func, 'func_code'):
+            # not in Python 3
+            patched.compat_co_firstlineno = getattr(
+                func, "compat_co_firstlineno",
+                func.func_code.co_firstlineno
+            )
+        return patched
+
+
+    def get_original(self):
+        target = self.getter()
+        name = self.attribute
+
+        original = DEFAULT
+        local = False
+
+        try:
+            original = target.__dict__[name]
+        except (AttributeError, KeyError):
+            original = getattr(target, name, DEFAULT)
+        else:
+            local = True
+
+        if not self.create and original is DEFAULT:
+            raise AttributeError(
+                "%s does not have the attribute %r" % (target, name)
+            )
+        return original, local
+
+
+    def __enter__(self):
+        """Perform the patch."""
+        new, spec, spec_set = self.new, self.spec, self.spec_set
+        autospec, kwargs = self.autospec, self.kwargs
+        new_callable = self.new_callable
+        self.target = self.getter()
+
+        # normalise False to None
+        if spec is False:
+            spec = None
+        if spec_set is False:
+            spec_set = None
+        if autospec is False:
+            autospec = None
+
+        if spec is not None and autospec is not None:
+            raise TypeError("Can't specify spec and autospec")
+        if ((spec is not None or autospec is not None) and
+            spec_set not in (True, None)):
+            raise TypeError("Can't provide explicit spec_set *and* spec or autospec")
+
+        original, local = self.get_original()
+
+        if new is DEFAULT and autospec is None:
+            inherit = False
+            if spec is True:
+                # set spec to the object we are replacing
+                spec = original
+                if spec_set is True:
+                    spec_set = original
+                    spec = None
+            elif spec is not None:
+                if spec_set is True:
+                    spec_set = spec
+                    spec = None
+            elif spec_set is True:
+                spec_set = original
+
+            if spec is not None or spec_set is not None:
+                if original is DEFAULT:
+                    raise TypeError("Can't use 'spec' with create=True")
+                if isinstance(original, ClassTypes):
+                    # If we're patching out a class and there is a spec
+                    inherit = True
+
+            Klass = MagicMock
+            _kwargs = {}
+            if new_callable is not None:
+                Klass = new_callable
+            elif spec is not None or spec_set is not None:
+                this_spec = spec
+                if spec_set is not None:
+                    this_spec = spec_set
+                if _is_list(this_spec):
+                    not_callable = '__call__' not in this_spec
+                else:
+                    not_callable = not _callable(this_spec)
+                if not_callable:
+                    Klass = NonCallableMagicMock
+
+            if spec is not None:
+                _kwargs['spec'] = spec
+            if spec_set is not None:
+                _kwargs['spec_set'] = spec_set
+
+            # add a name to mocks
+            if (isinstance(Klass, type) and
+                issubclass(Klass, NonCallableMock) and self.attribute):
+                _kwargs['name'] = self.attribute
+
+            _kwargs.update(kwargs)
+            new = Klass(**_kwargs)
+
+            if inherit and _is_instance_mock(new):
+                # we can only tell if the instance should be callable if the
+                # spec is not a list
+                this_spec = spec
+                if spec_set is not None:
+                    this_spec = spec_set
+                if (not _is_list(this_spec) and not
+                    _instance_callable(this_spec)):
+                    Klass = NonCallableMagicMock
+
+                _kwargs.pop('name')
+                new.return_value = Klass(_new_parent=new, _new_name='()',
+                                         **_kwargs)
+        elif autospec is not None:
+            # spec is ignored, new *must* be default, spec_set is treated
+            # as a boolean. Should we check spec is not None and that spec_set
+            # is a bool?
+            if new is not DEFAULT:
+                raise TypeError(
+                    "autospec creates the mock for you. Can't specify "
+                    "autospec and new."
+                )
+            if original is DEFAULT:
+                raise TypeError("Can't use 'autospec' with create=True")
+            spec_set = bool(spec_set)
+            if autospec is True:
+                autospec = original
+
+            new = create_autospec(autospec, spec_set=spec_set,
+                                  _name=self.attribute, **kwargs)
+        elif kwargs:
+            # can't set keyword args when we aren't creating the mock
+            # XXXX If new is a Mock we could call new.configure_mock(**kwargs)
+            raise TypeError("Can't pass kwargs to a mock we aren't creating")
+
+        new_attr = new
+
+        self.temp_original = original
+        self.is_local = local
+        setattr(self.target, self.attribute, new_attr)
+        if self.attribute_name is not None:
+            extra_args = {}
+            if self.new is DEFAULT:
+                extra_args[self.attribute_name] =  new
+            for patching in self.additional_patchers:
+                arg = patching.__enter__()
+                if patching.new is DEFAULT:
+                    extra_args.update(arg)
+            return extra_args
+
+        return new
+
+
+    def __exit__(self, *exc_info):
+        """Undo the patch."""
+        if not _is_started(self):
+            raise RuntimeError('stop called on unstarted patcher')
+
+        if self.is_local and self.temp_original is not DEFAULT:
+            setattr(self.target, self.attribute, self.temp_original)
+        else:
+            delattr(self.target, self.attribute)
+            if not self.create and not hasattr(self.target, self.attribute):
+                # needed for proxy objects like django settings
+                setattr(self.target, self.attribute, self.temp_original)
+
+        del self.temp_original
+        del self.is_local
+        del self.target
+        for patcher in reversed(self.additional_patchers):
+            if _is_started(patcher):
+                patcher.__exit__(*exc_info)
+
+
+    def start(self):
+        """Activate a patch, returning any created mock."""
+        result = self.__enter__()
+        self._active_patches.add(self)
+        return result
+
+
+    def stop(self):
+        """Stop an active patch."""
+        self._active_patches.discard(self)
+        return self.__exit__()
+
+
+
+def _get_target(target):
+    try:
+        target, attribute = target.rsplit('.', 1)
+    except (TypeError, ValueError):
+        raise TypeError("Need a valid target to patch. You supplied: %r" %
+                        (target,))
+    getter = lambda: _importer(target)
+    return getter, attribute
+
+
+def _patch_object(
+        target, attribute, new=DEFAULT, spec=None,
+        create=False, spec_set=None, autospec=None,
+        new_callable=None, **kwargs
+    ):
+    """
+    patch.object(target, attribute, new=DEFAULT, spec=None, create=False,
+                 spec_set=None, autospec=None, new_callable=None, **kwargs)
+
+    patch the named member (`attribute`) on an object (`target`) with a mock
+    object.
+
+    `patch.object` can be used as a decorator, class decorator or a context
+    manager. Arguments `new`, `spec`, `create`, `spec_set`,
+    `autospec` and `new_callable` have the same meaning as for `patch`. Like
+    `patch`, `patch.object` takes arbitrary keyword arguments for configuring
+    the mock object it creates.
+
+    When used as a class decorator `patch.object` honours `patch.TEST_PREFIX`
+    for choosing which methods to wrap.
+    """
+    getter = lambda: target
+    return _patch(
+        getter, attribute, new, spec, create,
+        spec_set, autospec, new_callable, kwargs
+    )
+
+
+def _patch_multiple(target, spec=None, create=False, spec_set=None,
+                    autospec=None, new_callable=None, **kwargs):
+    """Perform multiple patches in a single call. It takes the object to be
+    patched (either as an object or a string to fetch the object by importing)
+    and keyword arguments for the patches::
+
+        with patch.multiple(settings, FIRST_PATCH='one', SECOND_PATCH='two'):
+            ...
+
+    Use `DEFAULT` as the value if you want `patch.multiple` to create
+    mocks for you. In this case the created mocks are passed into a decorated
+    function by keyword, and a dictionary is returned when `patch.multiple` is
+    used as a context manager.
+
+    `patch.multiple` can be used as a decorator, class decorator or a context
+    manager. The arguments `spec`, `spec_set`, `create`,
+    `autospec` and `new_callable` have the same meaning as for `patch`. These
+    arguments will be applied to *all* patches done by `patch.multiple`.
+
+    When used as a class decorator `patch.multiple` honours `patch.TEST_PREFIX`
+    for choosing which methods to wrap.
+    """
+    if type(target) in (unicode, str):
+        getter = lambda: _importer(target)
+    else:
+        getter = lambda: target
+
+    if not kwargs:
+        raise ValueError(
+            'Must supply at least one keyword argument with patch.multiple'
+        )
+    # need to wrap in a list for python 3, where items is a view
+    items = list(kwargs.items())
+    attribute, new = items[0]
+    patcher = _patch(
+        getter, attribute, new, spec, create, spec_set,
+        autospec, new_callable, {}
+    )
+    patcher.attribute_name = attribute
+    for attribute, new in items[1:]:
+        this_patcher = _patch(
+            getter, attribute, new, spec, create, spec_set,
+            autospec, new_callable, {}
+        )
+        this_patcher.attribute_name = attribute
+        patcher.additional_patchers.append(this_patcher)
+    return patcher
+
+
+def patch(
+        target, new=DEFAULT, spec=None, create=False,
+        spec_set=None, autospec=None, new_callable=None, **kwargs
+    ):
+    """
+    `patch` acts as a function decorator, class decorator or a context
+    manager. Inside the body of the function or with statement, the `target`
+    is patched with a `new` object. When the function/with statement exits
+    the patch is undone.
+
+    If `new` is omitted, then the target is replaced with a
+    `MagicMock`. If `patch` is used as a decorator and `new` is
+    omitted, the created mock is passed in as an extra argument to the
+    decorated function. If `patch` is used as a context manager the created
+    mock is returned by the context manager.
+
+    `target` should be a string in the form `'package.module.ClassName'`. The
+    `target` is imported and the specified object replaced with the `new`
+    object, so the `target` must be importable from the environment you are
+    calling `patch` from. The target is imported when the decorated function
+    is executed, not at decoration time.
+
+    The `spec` and `spec_set` keyword arguments are passed to the `MagicMock`
+    if patch is creating one for you.
+
+    In addition you can pass `spec=True` or `spec_set=True`, which causes
+    patch to pass in the object being mocked as the spec/spec_set object.
+
+    `new_callable` allows you to specify a different class, or callable object,
+    that will be called to create the `new` object. By default `MagicMock` is
+    used.
+
+    A more powerful form of `spec` is `autospec`. If you set `autospec=True`
+    then the mock with be created with a spec from the object being replaced.
+    All attributes of the mock will also have the spec of the corresponding
+    attribute of the object being replaced. Methods and functions being
+    mocked will have their arguments checked and will raise a `TypeError` if
+    they are called with the wrong signature. For mocks replacing a class,
+    their return value (the 'instance') will have the same spec as the class.
+
+    Instead of `autospec=True` you can pass `autospec=some_object` to use an
+    arbitrary object as the spec instead of the one being replaced.
+
+    By default `patch` will fail to replace attributes that don't exist. If
+    you pass in `create=True`, and the attribute doesn't exist, patch will
+    create the attribute for you when the patched function is called, and
+    delete it again afterwards. This is useful for writing tests against
+    attributes that your production code creates at runtime. It is off by by
+    default because it can be dangerous. With it switched on you can write
+    passing tests against APIs that don't actually exist!
+
+    Patch can be used as a `TestCase` class decorator. It works by
+    decorating each test method in the class. This reduces the boilerplate
+    code when your test methods share a common patchings set. `patch` finds
+    tests by looking for method names that start with `patch.TEST_PREFIX`.
+    By default this is `test`, which matches the way `unittest` finds tests.
+    You can specify an alternative prefix by setting `patch.TEST_PREFIX`.
+
+    Patch can be used as a context manager, with the with statement. Here the
+    patching applies to the indented block after the with statement. If you
+    use "as" then the patched object will be bound to the name after the
+    "as"; very useful if `patch` is creating a mock object for you.
+
+    `patch` takes arbitrary keyword arguments. These will be passed to
+    the `Mock` (or `new_callable`) on construction.
+
+    `patch.dict(...)`, `patch.multiple(...)` and `patch.object(...)` are
+    available for alternate use-cases.
+    """
+    getter, attribute = _get_target(target)
+    return _patch(
+        getter, attribute, new, spec, create,
+        spec_set, autospec, new_callable, kwargs
+    )
+
+
+class _patch_dict(object):
+    """
+    Patch a dictionary, or dictionary like object, and restore the dictionary
+    to its original state after the test.
+
+    `in_dict` can be a dictionary or a mapping like container. If it is a
+    mapping then it must at least support getting, setting and deleting items
+    plus iterating over keys.
+
+    `in_dict` can also be a string specifying the name of the dictionary, which
+    will then be fetched by importing it.
+
+    `values` can be a dictionary of values to set in the dictionary. `values`
+    can also be an iterable of `(key, value)` pairs.
+
+    If `clear` is True then the dictionary will be cleared before the new
+    values are set.
+
+    `patch.dict` can also be called with arbitrary keyword arguments to set
+    values in the dictionary::
+
+        with patch.dict('sys.modules', mymodule=Mock(), other_module=Mock()):
+            ...
+
+    `patch.dict` can be used as a context manager, decorator or class
+    decorator. When used as a class decorator `patch.dict` honours
+    `patch.TEST_PREFIX` for choosing which methods to wrap.
+    """
+
+    def __init__(self, in_dict, values=(), clear=False, **kwargs):
+        if isinstance(in_dict, basestring):
+            in_dict = _importer(in_dict)
+        self.in_dict = in_dict
+        # support any argument supported by dict(...) constructor
+        self.values = dict(values)
+        self.values.update(kwargs)
+        self.clear = clear
+        self._original = None
+
+
+    def __call__(self, f):
+        if isinstance(f, ClassTypes):
+            return self.decorate_class(f)
+        @wraps(f)
+        def _inner(*args, **kw):
+            self._patch_dict()
+            try:
+                return f(*args, **kw)
+            finally:
+                self._unpatch_dict()
+
+        return _inner
+
+
+    def decorate_class(self, klass):
+        for attr in dir(klass):
+            attr_value = getattr(klass, attr)
+            if (attr.startswith(patch.TEST_PREFIX) and
+                 hasattr(attr_value, "__call__")):
+                decorator = _patch_dict(self.in_dict, self.values, self.clear)
+                decorated = decorator(attr_value)
+                setattr(klass, attr, decorated)
+        return klass
+
+
+    def __enter__(self):
+        """Patch the dict."""
+        self._patch_dict()
+
+
+    def _patch_dict(self):
+        values = self.values
+        in_dict = self.in_dict
+        clear = self.clear
+
+        try:
+            original = in_dict.copy()
+        except AttributeError:
+            # dict like object with no copy method
+            # must support iteration over keys
+            original = {}
+            for key in in_dict:
+                original[key] = in_dict[key]
+        self._original = original
+
+        if clear:
+            _clear_dict(in_dict)
+
+        try:
+            in_dict.update(values)
+        except AttributeError:
+            # dict like object with no update method
+            for key in values:
+                in_dict[key] = values[key]
+
+
+    def _unpatch_dict(self):
+        in_dict = self.in_dict
+        original = self._original
+
+        _clear_dict(in_dict)
+
+        try:
+            in_dict.update(original)
+        except AttributeError:
+            for key in original:
+                in_dict[key] = original[key]
+
+
+    def __exit__(self, *args):
+        """Unpatch the dict."""
+        self._unpatch_dict()
+        return False
+
+    start = __enter__
+    stop = __exit__
+
+
+def _clear_dict(in_dict):
+    try:
+        in_dict.clear()
+    except AttributeError:
+        keys = list(in_dict)
+        for key in keys:
+            del in_dict[key]
+
+
+def _patch_stopall():
+    """Stop all active patches."""
+    for patch in list(_patch._active_patches):
+        patch.stop()
+
+
+patch.object = _patch_object
+patch.dict = _patch_dict
+patch.multiple = _patch_multiple
+patch.stopall = _patch_stopall
+patch.TEST_PREFIX = 'test'
+
+magic_methods = (
+    "lt le gt ge eq ne "
+    "getitem setitem delitem "
+    "len contains iter "
+    "hash str sizeof "
+    "enter exit "
+    "divmod neg pos abs invert "
+    "complex int float index "
+    "trunc floor ceil "
+)
+
+numerics = "add sub mul div floordiv mod lshift rshift and xor or pow "
+inplace = ' '.join('i%s' % n for n in numerics.split())
+right = ' '.join('r%s' % n for n in numerics.split())
+extra = ''
+if inPy3k:
+    extra = 'bool next '
+else:
+    extra = 'unicode long nonzero oct hex truediv rtruediv '
+
+# not including __prepare__, __instancecheck__, __subclasscheck__
+# (as they are metaclass methods)
+# __del__ is not supported at all as it causes problems if it exists
+
+_non_defaults = set('__%s__' % method for method in [
+    'cmp', 'getslice', 'setslice', 'coerce', 'subclasses',
+    'format', 'get', 'set', 'delete', 'reversed',
+    'missing', 'reduce', 'reduce_ex', 'getinitargs',
+    'getnewargs', 'getstate', 'setstate', 'getformat',
+    'setformat', 'repr', 'dir'
+])
+
+
+def _get_method(name, func):
+    "Turns a callable object (like a mock) into a real function"
+    def method(self, *args, **kw):
+        return func(self, *args, **kw)
+    method.__name__ = name
+    return method
+
+
+_magics = set(
+    '__%s__' % method for method in
+    ' '.join([magic_methods, numerics, inplace, right, extra]).split()
+)
+
+_all_magics = _magics | _non_defaults
+
+_unsupported_magics = set([
+    '__getattr__', '__setattr__',
+    '__init__', '__new__', '__prepare__'
+    '__instancecheck__', '__subclasscheck__',
+    '__del__'
+])
+
+_calculate_return_value = {
+    '__hash__': lambda self: object.__hash__(self),
+    '__str__': lambda self: object.__str__(self),
+    '__sizeof__': lambda self: object.__sizeof__(self),
+    '__unicode__': lambda self: unicode(object.__str__(self)),
+}
+
+_return_values = {
+    '__lt__': NotImplemented,
+    '__gt__': NotImplemented,
+    '__le__': NotImplemented,
+    '__ge__': NotImplemented,
+    '__int__': 1,
+    '__contains__': False,
+    '__len__': 0,
+    '__exit__': False,
+    '__complex__': 1j,
+    '__float__': 1.0,
+    '__bool__': True,
+    '__nonzero__': True,
+    '__oct__': '1',
+    '__hex__': '0x1',
+    '__long__': long(1),
+    '__index__': 1,
+}
+
+
+def _get_eq(self):
+    def __eq__(other):
+        ret_val = self.__eq__._mock_return_value
+        if ret_val is not DEFAULT:
+            return ret_val
+        return self is other
+    return __eq__
+
+def _get_ne(self):
+    def __ne__(other):
+        if self.__ne__._mock_return_value is not DEFAULT:
+            return DEFAULT
+        return self is not other
+    return __ne__
+
+def _get_iter(self):
+    def __iter__():
+        ret_val = self.__iter__._mock_return_value
+        if ret_val is DEFAULT:
+            return iter([])
+        # if ret_val was already an iterator, then calling iter on it should
+        # return the iterator unchanged
+        return iter(ret_val)
+    return __iter__
+
+_side_effect_methods = {
+    '__eq__': _get_eq,
+    '__ne__': _get_ne,
+    '__iter__': _get_iter,
+}
+
+
+
+def _set_return_value(mock, method, name):
+    fixed = _return_values.get(name, DEFAULT)
+    if fixed is not DEFAULT:
+        method.return_value = fixed
+        return
+
+    return_calulator = _calculate_return_value.get(name)
+    if return_calulator is not None:
+        try:
+            return_value = return_calulator(mock)
+        except AttributeError:
+            # XXXX why do we return AttributeError here?
+            #      set it as a side_effect instead?
+            return_value = AttributeError(name)
+        method.return_value = return_value
+        return
+
+    side_effector = _side_effect_methods.get(name)
+    if side_effector is not None:
+        method.side_effect = side_effector(mock)
+
+
+
+class MagicMixin(object):
+    def __init__(self, *args, **kw):
+        _super(MagicMixin, self).__init__(*args, **kw)
+        self._mock_set_magics()
+
+
+    def _mock_set_magics(self):
+        these_magics = _magics
+
+        if self._mock_methods is not None:
+            these_magics = _magics.intersection(self._mock_methods)
+
+            remove_magics = set()
+            remove_magics = _magics - these_magics
+
+            for entry in remove_magics:
+                if entry in type(self).__dict__:
+                    # remove unneeded magic methods
+                    delattr(self, entry)
+
+        # don't overwrite existing attributes if called a second time
+        these_magics = these_magics - set(type(self).__dict__)
+
+        _type = type(self)
+        for entry in these_magics:
+            setattr(_type, entry, MagicProxy(entry, self))
+
+
+
+class NonCallableMagicMock(MagicMixin, NonCallableMock):
+    """A version of `MagicMock` that isn't callable."""
+    def mock_add_spec(self, spec, spec_set=False):
+        """Add a spec to a mock. `spec` can either be an object or a
+        list of strings. Only attributes on the `spec` can be fetched as
+        attributes from the mock.
+
+        If `spec_set` is True then only attributes on the spec can be set."""
+        self._mock_add_spec(spec, spec_set)
+        self._mock_set_magics()
+
+
+
+class MagicMock(MagicMixin, Mock):
+    """
+    MagicMock is a subclass of Mock with default implementations
+    of most of the magic methods. You can use MagicMock without having to
+    configure the magic methods yourself.
+
+    If you use the `spec` or `spec_set` arguments then *only* magic
+    methods that exist in the spec will be created.
+
+    Attributes and the return value of a `MagicMock` will also be `MagicMocks`.
+    """
+    def mock_add_spec(self, spec, spec_set=False):
+        """Add a spec to a mock. `spec` can either be an object or a
+        list of strings. Only attributes on the `spec` can be fetched as
+        attributes from the mock.
+
+        If `spec_set` is True then only attributes on the spec can be set."""
+        self._mock_add_spec(spec, spec_set)
+        self._mock_set_magics()
+
+
+
+class MagicProxy(object):
+    def __init__(self, name, parent):
+        self.name = name
+        self.parent = parent
+
+    def __call__(self, *args, **kwargs):
+        m = self.create_mock()
+        return m(*args, **kwargs)
+
+    def create_mock(self):
+        entry = self.name
+        parent = self.parent
+        m = parent._get_child_mock(name=entry, _new_name=entry,
+                                   _new_parent=parent)
+        setattr(parent, entry, m)
+        _set_return_value(parent, m, entry)
+        return m
+
+    def __get__(self, obj, _type=None):
+        return self.create_mock()
+
+
+
+class _ANY(object):
+    "A helper object that compares equal to everything."
+
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+    def __repr__(self):
+        return '<ANY>'
+
+ANY = _ANY()
+
+
+
+def _format_call_signature(name, args, kwargs):
+    message = '%s(%%s)' % name
+    formatted_args = ''
+    args_string = ', '.join([repr(arg) for arg in args])
+    kwargs_string = ', '.join([
+        '%s=%r' % (key, value) for key, value in kwargs.items()
+    ])
+    if args_string:
+        formatted_args = args_string
+    if kwargs_string:
+        if formatted_args:
+            formatted_args += ', '
+        formatted_args += kwargs_string
+
+    return message % formatted_args
+
+
+
+class _Call(tuple):
+    """
+    A tuple for holding the results of a call to a mock, either in the form
+    `(args, kwargs)` or `(name, args, kwargs)`.
+
+    If args or kwargs are empty then a call tuple will compare equal to
+    a tuple without those values. This makes comparisons less verbose::
+
+        _Call(('name', (), {})) == ('name',)
+        _Call(('name', (1,), {})) == ('name', (1,))
+        _Call(((), {'a': 'b'})) == ({'a': 'b'},)
+
+    The `_Call` object provides a useful shortcut for comparing with call::
+
+        _Call(((1, 2), {'a': 3})) == call(1, 2, a=3)
+        _Call(('foo', (1, 2), {'a': 3})) == call.foo(1, 2, a=3)
+
+    If the _Call has no name then it will match any name.
+    """
+    def __new__(cls, value=(), name=None, parent=None, two=False,
+                from_kall=True):
+        name = ''
+        args = ()
+        kwargs = {}
+        _len = len(value)
+        if _len == 3:
+            name, args, kwargs = value
+        elif _len == 2:
+            first, second = value
+            if isinstance(first, basestring):
+                name = first
+                if isinstance(second, tuple):
+                    args = second
+                else:
+                    kwargs = second
+            else:
+                args, kwargs = first, second
+        elif _len == 1:
+            value, = value
+            if isinstance(value, basestring):
+                name = value
+            elif isinstance(value, tuple):
+                args = value
+            else:
+                kwargs = value
+
+        if two:
+            return tuple.__new__(cls, (args, kwargs))
+
+        return tuple.__new__(cls, (name, args, kwargs))
+
+
+    def __init__(self, value=(), name=None, parent=None, two=False,
+                 from_kall=True):
+        self.name = name
+        self.parent = parent
+        self.from_kall = from_kall
+
+
+    def __eq__(self, other):
+        if other is ANY:
+            return True
+        try:
+            len_other = len(other)
+        except TypeError:
+            return False
+
+        self_name = ''
+        if len(self) == 2:
+            self_args, self_kwargs = self
+        else:
+            self_name, self_args, self_kwargs = self
+
+        other_name = ''
+        if len_other == 0:
+            other_args, other_kwargs = (), {}
+        elif len_other == 3:
+            other_name, other_args, other_kwargs = other
+        elif len_other == 1:
+            value, = other
+            if isinstance(value, tuple):
+                other_args = value
+                other_kwargs = {}
+            elif isinstance(value, basestring):
+                other_name = value
+                other_args, other_kwargs = (), {}
+            else:
+                other_args = ()
+                other_kwargs = value
+        else:
+            # len 2
+            # could be (name, args) or (name, kwargs) or (args, kwargs)
+            first, second = other
+            if isinstance(first, basestring):
+                other_name = first
+                if isinstance(second, tuple):
+                    other_args, other_kwargs = second, {}
+                else:
+                    other_args, other_kwargs = (), second
+            else:
+                other_args, other_kwargs = first, second
+
+        if self_name and other_name != self_name:
+            return False
+
+        # this order is important for ANY to work!
+        return (other_args, other_kwargs) == (self_args, self_kwargs)
+
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+    def __call__(self, *args, **kwargs):
+        if self.name is None:
+            return _Call(('', args, kwargs), name='()')
+
+        name = self.name + '()'
+        return _Call((self.name, args, kwargs), name=name, parent=self)
+
+
+    def __getattr__(self, attr):
+        if self.name is None:
+            return _Call(name=attr, from_kall=False)
+        name = '%s.%s' % (self.name, attr)
+        return _Call(name=name, parent=self, from_kall=False)
+
+
+    def __repr__(self):
+        if not self.from_kall:
+            name = self.name or 'call'
+            if name.startswith('()'):
+                name = 'call%s' % name
+            return name
+
+        if len(self) == 2:
+            name = 'call'
+            args, kwargs = self
+        else:
+            name, args, kwargs = self
+            if not name:
+                name = 'call'
+            elif not name.startswith('()'):
+                name = 'call.%s' % name
+            else:
+                name = 'call%s' % name
+        return _format_call_signature(name, args, kwargs)
+
+
+    def call_list(self):
+        """For a call object that represents multiple calls, `call_list`
+        returns a list of all the intermediate calls as well as the
+        final call."""
+        vals = []
+        thing = self
+        while thing is not None:
+            if thing.from_kall:
+                vals.append(thing)
+            thing = thing.parent
+        return _CallList(reversed(vals))
+
+
+call = _Call(from_kall=False)
+
+
+
+def create_autospec(spec, spec_set=False, instance=False, _parent=None,
+                    _name=None, **kwargs):
+    """Create a mock object using another object as a spec. Attributes on the
+    mock will use the corresponding attribute on the `spec` object as their
+    spec.
+
+    Functions or methods being mocked will have their arguments checked
+    to check that they are called with the correct signature.
+
+    If `spec_set` is True then attempting to set attributes that don't exist
+    on the spec object will raise an `AttributeError`.
+
+    If a class is used as a spec then the return value of the mock (the
+    instance of the class) will have the same spec. You can use a class as the
+    spec for an instance object by passing `instance=True`. The returned mock
+    will only be callable if instances of the mock are callable.
+
+    `create_autospec` also takes arbitrary keyword arguments that are passed to
+    the constructor of the created mock."""
+    if _is_list(spec):
+        # can't pass a list instance to the mock constructor as it will be
+        # interpreted as a list of strings
+        spec = type(spec)
+
+    is_type = isinstance(spec, ClassTypes)
+
+    _kwargs = {'spec': spec}
+    if spec_set:
+        _kwargs = {'spec_set': spec}
+    elif spec is None:
+        # None we mock with a normal mock without a spec
+        _kwargs = {}
+
+    _kwargs.update(kwargs)
+
+    Klass = MagicMock
+    if type(spec) in DescriptorTypes:
+        # descriptors don't have a spec
+        # because we don't know what type they return
+        _kwargs = {}
+    elif not _callable(spec):
+        Klass = NonCallableMagicMock
+    elif is_type and instance and not _instance_callable(spec):
+        Klass = NonCallableMagicMock
+
+    _new_name = _name
+    if _parent is None:
+        # for a top level object no _new_name should be set
+        _new_name = ''
+
+    mock = Klass(parent=_parent, _new_parent=_parent, _new_name=_new_name,
+                 name=_name, **_kwargs)
+
+    if isinstance(spec, FunctionTypes):
+        # should only happen at the top level because we don't
+        # recurse for functions
+        mock = _set_signature(mock, spec)
+    else:
+        _check_signature(spec, mock, is_type, instance)
+
+    if _parent is not None and not instance:
+        _parent._mock_children[_name] = mock
+
+    if is_type and not instance and 'return_value' not in kwargs:
+        mock.return_value = create_autospec(spec, spec_set, instance=True,
+                                            _name='()', _parent=mock)
+
+    for entry in dir(spec):
+        if _is_magic(entry):
+            # MagicMock already does the useful magic methods for us
+            continue
+
+        if isinstance(spec, FunctionTypes) and entry in FunctionAttributes:
+            # allow a mock to actually be a function
+            continue
+
+        # XXXX do we need a better way of getting attributes without
+        # triggering code execution (?) Probably not - we need the actual
+        # object to mock it so we would rather trigger a property than mock
+        # the property descriptor. Likewise we want to mock out dynamically
+        # provided attributes.
+        # XXXX what about attributes that raise exceptions other than
+        # AttributeError on being fetched?
+        # we could be resilient against it, or catch and propagate the
+        # exception when the attribute is fetched from the mock
+        try:
+            original = getattr(spec, entry)
+        except AttributeError:
+            continue
+
+        kwargs = {'spec': original}
+        if spec_set:
+            kwargs = {'spec_set': original}
+
+        if not isinstance(original, FunctionTypes):
+            new = _SpecState(original, spec_set, mock, entry, instance)
+            mock._mock_children[entry] = new
+        else:
+            parent = mock
+            if isinstance(spec, FunctionTypes):
+                parent = mock.mock
+
+            new = MagicMock(parent=parent, name=entry, _new_name=entry,
+                            _new_parent=parent, **kwargs)
+            mock._mock_children[entry] = new
+            skipfirst = _must_skip(spec, entry, is_type)
+            _check_signature(original, new, skipfirst=skipfirst)
+
+        # so functions created with _set_signature become instance attributes,
+        # *plus* their underlying mock exists in _mock_children of the parent
+        # mock. Adding to _mock_children may be unnecessary where we are also
+        # setting as an instance attribute?
+        if isinstance(new, FunctionTypes):
+            setattr(mock, entry, new)
+
+    return mock
+
+
+def _must_skip(spec, entry, is_type):
+    if not isinstance(spec, ClassTypes):
+        if entry in getattr(spec, '__dict__', {}):
+            # instance attribute - shouldn't skip
+            return False
+        spec = spec.__class__
+    if not hasattr(spec, '__mro__'):
+        # old style class: can't have descriptors anyway
+        return is_type
+
+    for klass in spec.__mro__:
+        result = klass.__dict__.get(entry, DEFAULT)
+        if result is DEFAULT:
+            continue
+        if isinstance(result, (staticmethod, classmethod)):
+            return False
+        return is_type
+
+    # shouldn't get here unless function is a dynamically provided attribute
+    # XXXX untested behaviour
+    return is_type
+
+
+def _get_class(obj):
+    try:
+        return obj.__class__
+    except AttributeError:
+        # in Python 2, _sre.SRE_Pattern objects have no __class__
+        return type(obj)
+
+
+class _SpecState(object):
+
+    def __init__(self, spec, spec_set=False, parent=None,
+                 name=None, ids=None, instance=False):
+        self.spec = spec
+        self.ids = ids
+        self.spec_set = spec_set
+        self.parent = parent
+        self.instance = instance
+        self.name = name
+
+
+FunctionTypes = (
+    # python function
+    type(create_autospec),
+    # instance method
+    type(ANY.__eq__),
+    # unbound method
+    type(_ANY.__eq__),
+)
+
+FunctionAttributes = set([
+    'func_closure',
+    'func_code',
+    'func_defaults',
+    'func_dict',
+    'func_doc',
+    'func_globals',
+    'func_name',
+])
+
+
+file_spec = None
+
+
+def mock_open(mock=None, read_data=''):
+    """
+    A helper function to create a mock to replace the use of `open`. It works
+    for `open` called directly or used as a context manager.
+
+    The `mock` argument is the mock object to configure. If `None` (the
+    default) then a `MagicMock` will be created for you, with the API limited
+    to methods or attributes available on standard file handles.
+
+    `read_data` is a string for the `read` method of the file handle to return.
+    This is an empty string by default.
+    """
+    global file_spec
+    if file_spec is None:
+        # set on first use
+        if inPy3k:
+            import _io
+            file_spec = list(set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO))))
+        else:
+            file_spec = file
+
+    if mock is None:
+        mock = MagicMock(name='open', spec=open)
+
+    handle = MagicMock(spec=file_spec)
+    handle.write.return_value = None
+    handle.__enter__.return_value = handle
+    handle.read.return_value = read_data
+
+    mock.return_value = handle
+    return mock
+
+
+class PropertyMock(Mock):
+    """
+    A mock intended to be used as a property, or other descriptor, on a class.
+    `PropertyMock` provides `__get__` and `__set__` methods so you can specify
+    a return value when it is fetched.
+
+    Fetching a `PropertyMock` instance from an object calls the mock, with
+    no args. Setting it calls the mock with the value being set.
+    """
+    def _get_child_mock(self, **kwargs):
+        return MagicMock(**kwargs)
+
+    def __get__(self, obj, obj_type):
+        return self()
+    def __set__(self, obj, val):
+        self(val)

--- a/ambari-metrics-host-monitoring/src/test/python/mock/mock.wpr
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/mock.wpr
@@ -1,0 +1,26 @@
+#!wing
+#!version=4.0
+##################################################################
+# Wing IDE project file                                          #
+##################################################################
+[project attributes]
+proj.directory-list = [{'dirloc': loc('.'),
+                        'excludes': [u'latex',
+                                     u'.hg',
+                                     u'.tox',
+                                     u'dist',
+                                     u'htmlcov',
+                                     u'extendmock.py',
+                                     u'__pycache__',
+                                     u'html',
+                                     u'build',
+                                     u'mock.egg-info',
+                                     u'tests/__pycache__',
+                                     u'.hgignore',
+                                     u'.hgtags'],
+                        'filter': '*',
+                        'include_hidden': 0,
+                        'recursive': 1,
+                        'watch_for_changes': 1}]
+proj.file-type = 'shared'
+testing.auto-test-file-specs = ('test*.py',)

--- a/ambari-metrics-host-monitoring/src/test/python/mock/setup.cfg
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/setup.cfg
@@ -1,0 +1,5 @@
+[build_sphinx]
+source-dir=docs
+build-dir=html
+[sdist]
+force-manifest = 1

--- a/ambari-metrics-host-monitoring/src/test/python/mock/setup.py
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/setup.py
@@ -1,0 +1,72 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2007-2012 Michael Foord & the mock team
+# E-mail: fuzzyman AT voidspace DOT org DOT uk
+# http://www.voidspace.org.uk/python/mock/
+
+from mock import __version__
+
+import os
+
+
+NAME = 'mock'
+MODULES = ['mock']
+DESCRIPTION = 'A Python Mocking and Patching Library for Testing'
+
+URL = "http://www.voidspace.org.uk/python/mock/"
+
+readme = os.path.join(os.path.dirname(__file__), 'README.txt')
+LONG_DESCRIPTION = open(readme).read()
+
+CLASSIFIERS = [
+    'Development Status :: 5 - Production/Stable',
+    'Environment :: Console',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: BSD License',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 2.5',
+    'Programming Language :: Python :: 2.6',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.1',
+    'Programming Language :: Python :: 3.2',
+    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: Implementation :: CPython',
+    'Programming Language :: Python :: Implementation :: PyPy',
+    'Programming Language :: Python :: Implementation :: Jython',
+    'Operating System :: OS Independent',
+    'Topic :: Software Development :: Libraries',
+    'Topic :: Software Development :: Libraries :: Python Modules',
+    'Topic :: Software Development :: Testing',
+]
+
+AUTHOR = 'Michael Foord'
+AUTHOR_EMAIL = 'michael@voidspace.org.uk'
+KEYWORDS = ("testing test mock mocking unittest patching "
+            "stubs fakes doubles").split(' ')
+
+params = dict(
+    name=NAME,
+    version=__version__,
+    py_modules=MODULES,
+
+    # metadata for upload to PyPI
+    author=AUTHOR,
+    author_email=AUTHOR_EMAIL,
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
+    keywords=KEYWORDS,
+    url=URL,
+    classifiers=CLASSIFIERS,
+)
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+else:
+    params['tests_require'] = ['unittest2']
+    params['test_suite'] = 'unittest2.collector'
+
+setup(**params)

--- a/ambari-metrics-host-monitoring/src/test/python/mock/tox.ini
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/tox.ini
@@ -1,0 +1,40 @@
+[tox]
+envlist = py25,py26,py27,py31,pypy,py32,py33,jython
+
+[testenv]
+deps=unittest2
+commands={envbindir}/unit2 discover []
+
+[testenv:py26]
+commands=
+    {envbindir}/unit2 discover []
+    {envbindir}/sphinx-build -E -b doctest docs html
+    {envbindir}/sphinx-build -E docs html
+deps =
+    unittest2
+    sphinx
+
+[testenv:py27]
+commands=
+    {envbindir}/unit2 discover []
+    {envbindir}/sphinx-build -E -b doctest docs html
+deps =
+    unittest2
+    sphinx
+
+[testenv:py31]
+deps =
+    unittest2py3k
+
+[testenv:py32]
+commands=
+    {envbindir}/python -m unittest discover []
+deps =
+
+[testenv:py33]
+commands=
+    {envbindir}/python -m unittest discover []
+deps =
+
+# note for jython. Execute in tests directory:
+# rm `find . -name '*$py.class'`

--- a/ambari-metrics-host-monitoring/src/test/python/mock/unittest.cfg
+++ b/ambari-metrics-host-monitoring/src/test/python/mock/unittest.cfg
@@ -1,0 +1,95 @@
+
+[unittest]
+plugins = 
+    unittest2.plugins.debugger
+    unittest2.plugins.checker
+    unittest2.plugins.doctestloader
+    unittest2.plugins.matchregexp
+    unittest2.plugins.moduleloading
+    unittest2.plugins.testcoverage
+    unittest2.plugins.growl
+    unittest2.plugins.filtertests
+    unittest2.plugins.junitxml
+    unittest2.plugins.timed
+    unittest2.plugins.counttests
+    unittest2.plugins.logchannels
+
+excluded-plugins =
+
+# 0, 1 or 2 (default is 1)
+# quiet, normal or verbose
+# can be overriden at command line
+verbosity = normal
+
+# true or false
+# even if false can be switched on at command line
+catch =
+buffer =
+failfast =
+
+
+[matchregexp]
+always-on = False
+full-path = True
+
+[debugger]
+always-on = False
+errors-only = True
+
+[coverage]
+always-on = False
+config =
+report-html = False
+# only used if report-html is false
+annotate = False
+# defaults to './htmlcov/'
+html-directory =
+# if unset will output to console
+text-file =
+branch = False
+timid = False
+cover-pylib = False
+exclude-lines = 
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.
+    
+ignore-errors = False
+modules =
+
+[growl]
+always-on = False
+
+[doctest]
+always-on = False
+
+[module-loading]
+always-on = False
+
+[checker]
+always-on = False
+pep8 = False
+pyflakes = True
+
+[junit-xml]
+always-on = False
+path = junit.xml
+
+[timed]
+always-on = True
+threshold = 0.01
+
+[count]
+always-on = True
+enhanced = False

--- a/ambari-metrics-host-monitoring/src/test/python/unitTests.py
+++ b/ambari-metrics-host-monitoring/src/test/python/unitTests.py
@@ -80,8 +80,6 @@ def main():
   pwd = os.path.abspath(os.path.dirname(__file__))
 
   project_folder = get_parent_path(pwd, 'ambari-metrics-host-monitoring')
-  sys.path.append(project_folder + "/target/ambari-python/site-packages")
-  sys.path.append(project_folder + "/target/ambari-python/site-packages/ambari_jinja2")
   sys.path.append(project_folder + "/src/main/python")
   sys.path.append(project_folder + "/src/main/python/core")
   sys.path.append(project_folder + "/src/main/resources/scripts")

--- a/ambari-metrics-host-monitoring/src/test/python/unitTests.py
+++ b/ambari-metrics-host-monitoring/src/test/python/unitTests.py
@@ -31,6 +31,7 @@ SERVICE_EXCLUDE = ["configs"]
 
 TEST_MASK = '[Tt]est*.py'
 CUSTOM_TEST_MASK = '_[Tt]est*.py'
+
 def get_parent_path(base, directory_name):
   """
   Returns absolute path for directory_name, if directory_name present in base.
@@ -75,9 +76,10 @@ def main():
   if len(sys.argv) > 1:
     if sys.argv[1] == "true":
       custom_tests = True
+
   pwd = os.path.abspath(os.path.dirname(__file__))
 
-  project_folder = get_parent_path(pwd,'ambari-metrics-host-monitoring')
+  project_folder = get_parent_path(pwd, 'ambari-metrics-host-monitoring')
   sys.path.append(project_folder + "/target/ambari-python/site-packages")
   sys.path.append(project_folder + "/target/ambari-python/site-packages/ambari_jinja2")
   sys.path.append(project_folder + "/src/main/python")
@@ -85,12 +87,14 @@ def main():
   sys.path.append(project_folder + "/src/main/resources/scripts")
   sys.path.append(project_folder + "/src/main/resources/custom_actions")
   sys.path.append(project_folder + "/target/psutil_build")
+  sys.path.append(project_folder + "/src/test/python")
 
   has_failures = False
   test_runs = 0
   test_failures = []
   test_errors = []
-  #run base ambari-server tests
+
+  # run base tests
   sys.stderr.write("Running tests\n")
   if custom_tests:
     test_mask = CUSTOM_TEST_MASK


### PR DESCRIPTION
## What changes were proposed in this pull request?

The unnecessary dep was added to support OS defaults and test functions around windows supportability added a few years back. Since then the windows support has not been supported by any developers and is no longer of any use. We recently separated the metrics repo and this dep creates a circular build time dependency.

## How was this patch tested?

Ran unit tests. Verified build.