### PR TITLE
[AMBARI-24652] Ambari metrics collector failed to show data for custo…

### DIFF
--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
@@ -657,6 +657,7 @@ public class TimelineMetricMetadataManager {
       appId = appId.toLowerCase();
     }
     */
+
     if (CollectionUtils.isNotEmpty(sanitizedHostNames)) {
       if (CollectionUtils.isNotEmpty(sanitizedMetricNames)) {
 

--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
@@ -655,7 +655,8 @@ public class TimelineMetricMetadataManager {
     /*
     if ( StringUtils.isNotEmpty(appId) && !(appId.equals("HOST") || appId.equals("FLUME_HANDLER"))) { //HACK.. Why??
       appId = appId.toLowerCase();
-    }*/
+    }
+    */
     if (CollectionUtils.isNotEmpty(sanitizedHostNames)) {
       if (CollectionUtils.isNotEmpty(sanitizedMetricNames)) {
 

--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
@@ -651,10 +651,11 @@ public class TimelineMetricMetadataManager {
     }
 
     Set<String> sanitizedHostNames = getSanitizedHostnames(hostnames);
-
+    //converting to lower case is not needed as Collector inserts Appids even with Upper case.
+    /*
     if ( StringUtils.isNotEmpty(appId) && !(appId.equals("HOST") || appId.equals("FLUME_HANDLER"))) { //HACK.. Why??
       appId = appId.toLowerCase();
-    }
+    }*/
     if (CollectionUtils.isNotEmpty(sanitizedHostNames)) {
       if (CollectionUtils.isNotEmpty(sanitizedMetricNames)) {
 


### PR DESCRIPTION
…m metrics (apappu)

## What changes were proposed in this pull request?
In Fetch API call , appid is being converted into lower case , have removed that statement.
(Please fill in changes proposed in this fix)


(Please fill in changes proposed in this fix)

## How was this patch tested?
Deployed the changes in running AMS server and made API calls with upper case appid and lower case appid - it returned the correct response.
deployed the fix and validated few screens in Grafana and Ambari - it worked fine.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
