### PR TITLE
[AMBARI-25514]: Build fails on missing javax.el

### DIFF
--- a/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics-timelineservice/pom.xml
@@ -366,6 +366,10 @@
           <groupId>org.glassfish.jersey.containers</groupId>
         </exclusion>
         <exclusion>
+          <artifactId>javax.el</artifactId>
+          <groupId>org.glassfish</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>javax.ws.rs-api</artifactId>
           <groupId>javax.ws.rs</groupId>
         </exclusion>
@@ -726,6 +730,10 @@
         <exclusion>
           <artifactId>jersey-container-servlet-core</artifactId>
           <groupId>org.glassfish.jersey.containers</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>javax.el</artifactId>
+          <groupId>org.glassfish</groupId>
         </exclusion>
         <exclusion>
           <artifactId>javax.ws.rs-api</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude javax.el from phoenix-core

## How was this patch tested?

I test it on Debian 9 with a Maven cache emptied from scratch (and really ensure not old missed cached dependency errors occurs)