### PR TITLE
AMBARI-25596: Multiple Ambari Unit Tests failing due to Address already in use

### DIFF
--- a/ambari-metrics-host-aggregator/src/test/java/org/apache/hadoop/metrics2/RandomPortJerseyTest.java
+++ b/ambari-metrics-host-aggregator/src/test/java/org/apache/hadoop/metrics2/RandomPortJerseyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.hadoop.metrics2;
+
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * Makes JerseyTest use random port in case default one is unavailable.
+ */
+public class RandomPortJerseyTest extends JerseyTest {
+  private static int testPort;
+
+  public RandomPortJerseyTest(AppDescriptor ad) {
+    super(ad);
+  }
+
+  @Override
+  protected int getPort(int defaultPort) {
+    ServerSocket server = null;
+    int port = -1;
+    try {
+      server = new ServerSocket(defaultPort);
+      port = server.getLocalPort();
+    } catch (IOException e) {
+    } finally {
+      if (server != null) {
+        try {
+          server.close();
+        } catch (IOException e) {
+        }
+      }
+    }
+    if ((port != -1) || (defaultPort == 0)) {
+      this.testPort = port;
+      return port;
+    }
+    return getPort(0);
+  }
+}

--- a/ambari-metrics-host-aggregator/src/test/java/org/apache/hadoop/metrics2/host/aggregator/AggregatorWebServiceTest.java
+++ b/ambari-metrics-host-aggregator/src/test/java/org/apache/hadoop/metrics2/host/aggregator/AggregatorWebServiceTest.java
@@ -22,114 +22,112 @@ package org.apache.hadoop.metrics2.host.aggregator;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.api.client.config.DefaultClientConfig;
-import com.sun.jersey.test.framework.JerseyTest;
 import com.sun.jersey.test.framework.WebAppDescriptor;
 import com.sun.jersey.test.framework.spi.container.TestContainerFactory;
 import com.sun.jersey.test.framework.spi.container.grizzly2.GrizzlyTestContainerFactory;
 import junit.framework.Assert;
+import org.apache.hadoop.metrics2.RandomPortJerseyTest;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 import org.codehaus.jackson.jaxrs.JacksonJaxbJsonProvider;
 import org.junit.Test;
 
-
 import javax.ws.rs.core.MediaType;
-
 import java.util.Collection;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
 
-public class AggregatorWebServiceTest extends JerseyTest {
-    public AggregatorWebServiceTest() {
-        super(new WebAppDescriptor.Builder(
-                "org.apache.hadoop.metrics2.host.aggregator")
-                .contextPath("jersey-guice-filter")
-                .servletPath("/")
-                .clientConfig(new DefaultClientConfig(JacksonJaxbJsonProvider.class))
-                .build());
+public class AggregatorWebServiceTest extends RandomPortJerseyTest {
+  public AggregatorWebServiceTest() {
+    super(new WebAppDescriptor.Builder(
+            "org.apache.hadoop.metrics2.host.aggregator")
+            .contextPath("jersey-guice-filter")
+            .servletPath("/")
+            .clientConfig(new DefaultClientConfig(JacksonJaxbJsonProvider.class))
+            .build());
+  }
+
+  @Override
+  public TestContainerFactory getTestContainerFactory() {
+    return new GrizzlyTestContainerFactory();
+  }
+
+  @Test
+  public void testOkResponse() {
+    WebResource r = resource();
+    ClientResponse response = r.path("ws").path("v1").path("timeline").path("metrics")
+            .accept("text/json")
+            .get(ClientResponse.class);
+    assertEquals(200, response.getStatus());
+    assertEquals("text/json", response.getType().toString());
+  }
+
+  @Test
+  public void testWrongPath() {
+    WebResource r = resource();
+    ClientResponse response = r.path("ws").path("v1").path("timeline").path("metrics").path("aggregated")
+            .accept("text/json")
+            .get(ClientResponse.class);
+    assertEquals(404, response.getStatus());
+  }
+
+
+  @Test
+  public void testMetricsPost() {
+    TimelineMetricsHolder timelineMetricsHolder = TimelineMetricsHolder.getInstance();
+
+    timelineMetricsHolder.extractMetricsForAggregationPublishing();
+    timelineMetricsHolder.extractMetricsForRawPublishing();
+
+    TimelineMetrics timelineMetrics = TimelineMetricsHolderTest.getTimelineMetricsWithAppID("appid");
+    WebResource r = resource();
+    ClientResponse response = r.path("ws").path("v1").path("timeline").path("metrics")
+            .accept(MediaType.TEXT_PLAIN)
+            .post(ClientResponse.class, timelineMetrics);
+    assertEquals(200, response.getStatus());
+    assertEquals(MediaType.TEXT_PLAIN, response.getType().toString());
+
+    Map<String, TimelineMetrics> aggregationMap = timelineMetricsHolder.extractMetricsForAggregationPublishing();
+    Map<String, TimelineMetrics> rawMap = timelineMetricsHolder.extractMetricsForRawPublishing();
+
+    Assert.assertEquals(1, aggregationMap.size());
+    Assert.assertEquals(1, rawMap.size());
+
+    Collection<TimelineMetrics> aggregationCollection = aggregationMap.values();
+    Collection<TimelineMetrics> rawCollection = rawMap.values();
+
+    Collection<String> aggregationCollectionKeys = aggregationMap.keySet();
+    Collection<String> rawCollectionKeys = rawMap.keySet();
+
+    for (String key : aggregationCollectionKeys) {
+      Assert.assertTrue(key.contains("appid"));
     }
 
-    @Override
-    public TestContainerFactory getTestContainerFactory() {
-        return new GrizzlyTestContainerFactory();
+    for (String key : rawCollectionKeys) {
+      Assert.assertTrue(key.contains("appid"));
     }
 
-    @Test
-    public void testOkResponse() {
-        WebResource r = resource();
-        ClientResponse response = r.path("ws").path("v1").path("timeline").path("metrics")
-                .accept("text/json")
-                .get(ClientResponse.class);
-        assertEquals(200, response.getStatus());
-        assertEquals("text/json", response.getType().toString());
-    }
+    Assert.assertEquals(1, aggregationCollection.size());
+    Assert.assertEquals(1, rawCollection.size());
 
-    @Test
-    public void testWrongPath() {
-        WebResource r = resource();
-        ClientResponse response = r.path("ws").path("v1").path("timeline").path("metrics").path("aggregated")
-                .accept("text/json")
-                .get(ClientResponse.class);
-        assertEquals(404, response.getStatus());
-    }
+    TimelineMetrics aggregationTimelineMetrics = (TimelineMetrics) aggregationCollection.toArray()[0];
+    TimelineMetrics rawTimelineMetrics = (TimelineMetrics) rawCollection.toArray()[0];
 
 
-    @Test
-    public void testMetricsPost() {
-        TimelineMetricsHolder timelineMetricsHolder = TimelineMetricsHolder.getInstance();
+    Assert.assertEquals(1, aggregationTimelineMetrics.getMetrics().size());
+    Assert.assertEquals(1, rawTimelineMetrics.getMetrics().size());
 
-        timelineMetricsHolder.extractMetricsForAggregationPublishing();
-        timelineMetricsHolder.extractMetricsForRawPublishing();
+    Assert.assertEquals("appid", aggregationTimelineMetrics.getMetrics().get(0).getAppId());
+    Assert.assertEquals("appid", rawTimelineMetrics.getMetrics().get(0).getAppId());
 
-        TimelineMetrics timelineMetrics = TimelineMetricsHolderTest.getTimelineMetricsWithAppID("appid");
-        WebResource r = resource();
-        ClientResponse response = r.path("ws").path("v1").path("timeline").path("metrics")
-                .accept(MediaType.TEXT_PLAIN)
-                .post(ClientResponse.class, timelineMetrics);
-        assertEquals(200, response.getStatus());
-        assertEquals(MediaType.TEXT_PLAIN, response.getType().toString());
+    aggregationMap = timelineMetricsHolder.extractMetricsForAggregationPublishing();
+    rawMap = timelineMetricsHolder.extractMetricsForRawPublishing();
 
-        Map<String, TimelineMetrics> aggregationMap =  timelineMetricsHolder.extractMetricsForAggregationPublishing();
-        Map<String, TimelineMetrics> rawMap =  timelineMetricsHolder.extractMetricsForRawPublishing();
-
-        Assert.assertEquals(1, aggregationMap.size());
-        Assert.assertEquals(1, rawMap.size());
-
-        Collection<TimelineMetrics> aggregationCollection = aggregationMap.values();
-        Collection<TimelineMetrics> rawCollection = rawMap.values();
-
-        Collection<String> aggregationCollectionKeys = aggregationMap.keySet();
-        Collection<String> rawCollectionKeys = rawMap.keySet();
-
-        for (String key : aggregationCollectionKeys) {
-            Assert.assertTrue(key.contains("appid"));
-        }
-
-        for (String key : rawCollectionKeys) {
-            Assert.assertTrue(key.contains("appid"));
-        }
-
-        Assert.assertEquals(1, aggregationCollection.size());
-        Assert.assertEquals(1, rawCollection.size());
-
-        TimelineMetrics aggregationTimelineMetrics = (TimelineMetrics) aggregationCollection.toArray()[0];
-        TimelineMetrics rawTimelineMetrics = (TimelineMetrics) rawCollection.toArray()[0];
-
-
-        Assert.assertEquals(1, aggregationTimelineMetrics.getMetrics().size());
-        Assert.assertEquals(1, rawTimelineMetrics.getMetrics().size());
-
-        Assert.assertEquals("appid", aggregationTimelineMetrics.getMetrics().get(0).getAppId());
-        Assert.assertEquals("appid", rawTimelineMetrics.getMetrics().get(0).getAppId());
-
-        aggregationMap =  timelineMetricsHolder.extractMetricsForAggregationPublishing();
-        rawMap =  timelineMetricsHolder.extractMetricsForRawPublishing();
-
-        //Cache should be empty after extraction
-        Assert.assertEquals(0, aggregationMap.size());
-        Assert.assertEquals(0, rawMap.size());
-    }
+    //Cache should be empty after extraction
+    Assert.assertEquals(0, aggregationMap.size());
+    Assert.assertEquals(0, rawMap.size());
+  }
 
 
 }

--- a/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/RandomPortJerseyTest.java
+++ b/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/RandomPortJerseyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.ambari.metrics;
+
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * Makes JerseyTest use random port in case default one is unavailable.
+ */
+public class RandomPortJerseyTest extends JerseyTest {
+  private static int testPort;
+
+  public RandomPortJerseyTest(AppDescriptor ad) {
+    super(ad);
+  }
+
+  @Override
+  protected int getPort(int defaultPort) {
+    ServerSocket server = null;
+    int port = -1;
+    try {
+      server = new ServerSocket(defaultPort);
+      port = server.getLocalPort();
+    } catch (IOException e) {
+    } finally {
+      if (server != null) {
+        try {
+          server.close();
+        } catch (IOException e) {
+        }
+      }
+    }
+    if ((port != -1) || (defaultPort == 0)) {
+      this.testPort = port;
+      return port;
+    }
+    return getPort(0);
+  }
+}

--- a/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/webapp/TestTimelineWebServices.java
+++ b/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/webapp/TestTimelineWebServices.java
@@ -18,18 +18,6 @@
 
 package org.apache.ambari.metrics.webapp;
 
-import static org.junit.Assert.assertEquals;
-
-import javax.ws.rs.core.MediaType;
-
-import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
-import org.apache.ambari.metrics.core.timeline.TestTimelineMetricStore;
-import org.apache.ambari.metrics.core.timeline.TimelineMetricStore;
-import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
-import org.apache.hadoop.yarn.webapp.JerseyTestBase;
-import org.apache.hadoop.yarn.webapp.YarnJacksonJaxbJsonProvider;
-import org.junit.Test;
-
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.servlet.GuiceServletContextListener;
@@ -38,13 +26,22 @@ import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
-import com.sun.jersey.test.framework.JerseyTest;
 import com.sun.jersey.test.framework.WebAppDescriptor;
-
 import junit.framework.Assert;
+import org.apache.ambari.metrics.RandomPortJerseyTest;
+import org.apache.ambari.metrics.core.timeline.TestTimelineMetricStore;
+import org.apache.ambari.metrics.core.timeline.TimelineMetricStore;
+import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
+import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
+import org.apache.hadoop.yarn.webapp.YarnJacksonJaxbJsonProvider;
+import org.junit.Test;
+
+import javax.ws.rs.core.MediaType;
+
+import static org.junit.Assert.assertEquals;
 
 
-public class TestTimelineWebServices extends JerseyTestBase {
+public class TestTimelineWebServices extends RandomPortJerseyTest {
   private static TimelineMetricStore metricStore;
   private long beforeTime;
 
@@ -76,28 +73,28 @@ public class TestTimelineWebServices extends JerseyTestBase {
 
   public TestTimelineWebServices() {
     super(new WebAppDescriptor.Builder(
-      "org.apache.ambari.metrics.webapp")
-      .contextListenerClass(GuiceServletConfig.class)
-      .filterClass(com.google.inject.servlet.GuiceFilter.class)
-      .contextPath("jersey-guice-filter")
-      .servletPath("/")
-      .clientConfig(new DefaultClientConfig(YarnJacksonJaxbJsonProvider.class))
-      .build());
+            "org.apache.ambari.metrics.webapp")
+            .contextListenerClass(GuiceServletConfig.class)
+            .filterClass(com.google.inject.servlet.GuiceFilter.class)
+            .contextPath("jersey-guice-filter")
+            .servletPath("/")
+            .clientConfig(new DefaultClientConfig(YarnJacksonJaxbJsonProvider.class))
+            .build());
   }
 
   @Test
   public void testAbout() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
-      .accept(MediaType.APPLICATION_JSON)
-      .get(ClientResponse.class);
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getType());
     TimelineWebServices.AboutInfo about =
-      response.getEntity(TimelineWebServices.AboutInfo.class);
+            response.getEntity(TimelineWebServices.AboutInfo.class);
     Assert.assertNotNull(about);
     Assert.assertEquals("AMS API", about.getAbout());
   }
-  
+
   private static void verifyMetrics(TimelineMetrics metrics) {
     Assert.assertNotNull(metrics);
     Assert.assertEquals("cpu_user", metrics.getMetrics().get(0).getMetricName());
@@ -110,9 +107,9 @@ public class TestTimelineWebServices extends JerseyTestBase {
   public void testGetMetrics() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
-      .path("metrics").queryParam("metricNames", "cpu_user").queryParam("precision", "seconds")
-      .accept(MediaType.APPLICATION_JSON)
-      .get(ClientResponse.class);
+            .path("metrics").queryParam("metricNames", "cpu_user").queryParam("precision", "seconds")
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getType());
     verifyMetrics(response.getEntity(TimelineMetrics.class));
   }

--- a/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/webapp/TestTimelineWebServices.java
+++ b/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/webapp/TestTimelineWebServices.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 import org.apache.ambari.metrics.core.timeline.TestTimelineMetricStore;
 import org.apache.ambari.metrics.core.timeline.TimelineMetricStore;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
+import org.apache.hadoop.yarn.webapp.JerseyTestBase;
 import org.apache.hadoop.yarn.webapp.YarnJacksonJaxbJsonProvider;
 import org.junit.Test;
 
@@ -43,7 +44,7 @@ import com.sun.jersey.test.framework.WebAppDescriptor;
 import junit.framework.Assert;
 
 
-public class TestTimelineWebServices extends JerseyTest {
+public class TestTimelineWebServices extends JerseyTestBase {
   private static TimelineMetricStore metricStore;
   private long beforeTime;
 


### PR DESCRIPTION
Issue:
```
Running org.apache.ambari.metrics.webapp.TestTimelineWebServicesTests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.294 sec <<< FAILURE! - in org.apache.ambari.metrics.webapp.TestTimelineWebServicestestAbout(org.apache.ambari.metrics.webapp.TestTimelineWebServices) 
Time elapsed: 0.005 sec  
<<< ERROR!com.sun.jersey.test.framework.spi.container.TestContainerException: java.net.BindException: Address already in use
at org.apache.ambari.metrics.webapp.TestTimelineWebServices.<init>(TestTimelineWebServices.java:77)
Caused by: java.net.BindException: Address already in useat org.apache.ambari.metrics.webapp.TestTimelineWebServices.<init>(TestTimelineWebServices.java:77)
testGetMetrics(org.apache.ambari.metrics.webapp.TestTimelineWebServices)  
Time elapsed: 0.001 sec  <<< ERROR!com.sun.jersey.test.framework.spi.container.TestContainerException: java.net.BindException: Address already in use
at org.apache.ambari.metrics.webapp.TestTimelineWebServices.<init>(TestTimelineWebServices.java:77)
Caused by: java.net.BindException: Address already in use
at org.apache.ambari.metrics.webapp.TestTimelineWebServices.<init>(TestTimelineWebServices.java:77)
Results :Tests in error:TestTimelineWebServices.<init>:77->JerseyTestBase.<init>:27->JerseyTest.<init>:217->JerseyTest.getContainer:342 » TestContainerTestTimelineWebServices.<init>:77->JerseyTestBase.<init>:27->JerseyTest.<init>:217->JerseyTest.getContainer:342 » TestContainer
```

Fix:
I am using the JerseyTestBase class from yarn that uses incremental port number to find the free port.

Test:
Test is now passing locally successfully