### PR TITLE
AMBARI-25348: Change apache-hadoop repository from private nexus to public in AMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <repository>
       <id>apache-hadoop</id>
       <name>hdp</name>
-      <url>http://nexus-private.hortonworks.com/nexus/content/groups/public</url>
+      <url>https://repo.hortonworks.com/content/groups/public/</url>
     </repository>
     <repository>
       <id>apache-snapshots</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Forward port commit [bca762e](https://github.com/apache/ambari/commit/bca762eeb578054dc219120a54984a4ad58a9fbb) on Ambari branch-2.7

Also change http to https
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
