### PR TITLE
[AMBARI-25301] Ambari metrics HA does not work in 2.7.x for Hbase/any…

### DIFF
--- a/ambari-metrics-hadoop-sink/src/main/java/org/apache/hadoop/metrics2/sink/timeline/HadoopTimelineMetricsSink.java
+++ b/ambari-metrics-hadoop-sink/src/main/java/org/apache/hadoop/metrics2/sink/timeline/HadoopTimelineMetricsSink.java
@@ -108,7 +108,12 @@ public class HadoopTimelineMetricsSink extends AbstractTimelineMetricsSink imple
 
     // Load collector configs
     protocol = conf.getString(COLLECTOR_PROTOCOL, "http");
-    collectorHosts = parseHostsStringArrayIntoCollection(conf.getStringArray(COLLECTOR_HOSTS_PROPERTY));
+    String collectorHostStr = conf.getString(COLLECTOR_HOSTS_PROPERTY);
+    String[] collectorHostArr = null;
+    if(collectorHostStr !=null) {
+      collectorHostArr = collectorHostStr.split(",");
+    }
+    collectorHosts = parseHostsStringArrayIntoCollection(collectorHostArr);
     port = conf.getString(COLLECTOR_PORT, "6188");
     hostInMemoryAggregationEnabled = conf.getBoolean(HOST_IN_MEMORY_AGGREGATION_ENABLED_PROPERTY, false);
     hostInMemoryAggregationPort = conf.getInt(HOST_IN_MEMORY_AGGREGATION_PORT_PROPERTY, 61888);


### PR DESCRIPTION
… /services (apappu)

## What changes were proposed in this pull request?

[AMBARI-25301] Ambari metrics HA does not work in 2.7.x for Hbase/any /services (apappu)


