### PR TITLE
AMBARI-25587 Metrics cannot be stored and the exception message is nu…

### DIFF
--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AggregatorUtils.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/aggregators/AggregatorUtils.java
@@ -49,7 +49,7 @@ public class AggregatorUtils {
     if (metricValues != null && !metricValues.isEmpty()) {
       for (Double value : metricValues.values()) {
         // TODO: Some nulls in data - need to investigate null values from host
-        if (value != null) {
+        if (value != null && !value.isNaN()) {
           if (value > max) {
             max = value;
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

AMBARI-25587 Metrics cannot be stored and the exception message is null when metric value is NaN

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
