### PR TITLE
AMBARI-25808: Metrics data simulator throws NPE

### DIFF
--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/loadsimulator/data/AppID.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/loadsimulator/data/AppID.java
@@ -23,15 +23,15 @@ public enum AppID {
   RESOURCEMANAGER("resourcemanager"),
   DATANODE("datanode"),
   NODEMANAGER("nodemanager"),
-  MASTER_HBASE("hbase"),
-  SLAVE_HBASE("hbase"),
+  HBASE_MASTER("hbase"),
+  HBASE_REGIONSERVER("hbase"),
   NIMBUS("nimbus"),
   HIVEMETASTORE("hivemetastore"),
   HIVESERVER2("hiveserver2"),
   KAFKA_BROKER("kafka_broker");
 
-  public static final AppID[] MASTER_APPS = {HOST, NAMENODE, RESOURCEMANAGER, MASTER_HBASE, KAFKA_BROKER, NIMBUS, HIVEMETASTORE, HIVESERVER2};
-  public static final AppID[] SLAVE_APPS = {HOST, DATANODE, NODEMANAGER, SLAVE_HBASE};
+  public static final AppID[] MASTER_APPS = {HOST, NAMENODE, RESOURCEMANAGER, HBASE_MASTER, KAFKA_BROKER, NIMBUS, HIVEMETASTORE, HIVESERVER2};
+  public static final AppID[] SLAVE_APPS = {HOST, DATANODE, NODEMANAGER, HBASE_REGIONSERVER};
 
   private String id;
 


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

Changed the AppId to match the data file names metrics_def/HBASE_REGIONSERVER.dat and metrics_def/HBASE_MASTER.dat

## How was this patch tested?
build and executed data simulator start command  as below, there was no NPE
`bin % ./start.sh  localhost:6188 2`

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
