### PR TITLE
AMBARI-25809: ambari-metrics-host-monitoring project build creates temp folder outside of target folder

### DIFF
--- a/ambari-metrics-host-monitoring/pom.xml
+++ b/ambari-metrics-host-monitoring/pom.xml
@@ -192,7 +192,7 @@
                       <arg value="setup.py" />
                       <arg value="build" />
                       <arg value="--build-temp" />
-                      <arg value="${basedir}\target\psutil_build_temp" />
+                      <arg value="${basedir}/target/psutil_build_temp" />
                       <arg value="--build-base" />
                       <arg value="${basedir}/target/psutil_build" />
                     </exec>


### PR DESCRIPTION

<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

Created the temp folder inside the target folder

## How was this patch tested?

Run  mvn clean install -DskipTests then run git status to know the folder creation status
```
% git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	"../ambari-metrics-host-monitoring\\target\\psutil_build_temp/"
```
There is no untracked folder after the fix

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
