### PR TITLE
AMBARI-25811: Optimize ambari metrics build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,7 @@
        </plugin>
        <plugin>
          <artifactId>maven-assembly-plugin</artifactId>
+         <version>3.4.2</version>
          <configuration>
            <descriptors>
              <descriptor>../ambari-project/src/main/assemblies/empty.xml</descriptor>


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

Upgrade maven-assembly-plugin from 2.2-beta-5 to 3.4.2(latest version).
This reduces the ambari metrics build time from 10 min to 2 min

## How was this patch tested?

Built before and after the change and observed the build time reduction.
Please refer https://issues.apache.org/jira/browse/AMBARI-25811 for detail

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
