### PR TITLE
AMBARI-25893: metrics collector's sqlline.py cannot start normally due to missing dependency

### DIFF
--- a/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics-timelineservice/pom.xml
@@ -34,6 +34,7 @@
     <!-- Needed for generating FindBugs warnings using parent pom -->
     <!--<yarn.basedir>${project.parent.parent.basedir}</yarn.basedir>-->
     <protobuf.version>2.5.0</protobuf.version>
+    <sqlline.version>1.9.0</sqlline.version>
   </properties>
 
   <build>
@@ -329,6 +330,11 @@
           <groupId>jline</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>sqlline</groupId>
+      <artifactId>sqlline</artifactId>
+      <version>${sqlline.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.phoenix</groupId>


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

Add missing sqlline jar dependency for metrics-timelineservice.

## How was this patch tested?

After adding the sqlline dependency in the pom, then package and run sqlling.py again, which runs very well immediately.

