### PR TITLE
AMBARI-25865: Fix an unit test failure on ambari-metrics-host-monitoring

### DIFF
--- a/ambari-metrics-host-monitoring/pom.xml
+++ b/ambari-metrics-host-monitoring/pom.xml
@@ -44,7 +44,7 @@
             <fileset>
               <directory>${project.basedir}/src/main/python/psutil/build/</directory>
               <includes>
-                <include>**/*</include>
+                <include>**</include>
               </includes>
               <followSymlinks>false</followSymlinks>
             </fileset>
@@ -188,10 +188,6 @@
                     <exec dir="${basedir}/src/main/python/psutil" executable="${executable.python}" failonerror="true">
                       <arg value="setup.py" />
                       <arg value="build" />
-                      <arg value="--build-temp" />
-                      <arg value="${basedir}/target/psutil_build_temp" />
-                      <arg value="--build-base" />
-                      <arg value="${basedir}/target/psutil_build" />
                     </exec>
                   </target>
                 </configuration>

--- a/ambari-metrics-host-monitoring/src/test/python/unitTests.py
+++ b/ambari-metrics-host-monitoring/src/test/python/unitTests.py
@@ -100,8 +100,11 @@ def main():
     test_mask = TEST_MASK
 
   tests = get_test_files(pwd, mask=test_mask, recursive=True)
-  shuffle(tests)
   modules = [os.path.basename(s)[:-3] for s in tests]
+  # Workaround for AMBARI-25865. This avoids loading psutil too early.
+  i = modules.index("TestHostInfo")
+  if -1 < i:
+    modules.append(modules.pop(i))
   suites = [unittest.defaultTestLoader.loadTestsFromName(name) for name in
     modules]
   testSuite = unittest.TestSuite(suites)


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

Currently, we have a unit test failure in ambari-metrics-host-monitoring, as follows:

```
$ mvn clean test -f ambari-metrics-host-monitoring/pom.xml

...

[INFO] --- exec-maven-plugin:1.2.1:exec (python-test) @ ambari-metrics-host-monitoring ---
Running tests
Traceback (most recent call last):
  File "unitTests.py", line 137, in <module>
    sys.exit(main())
  File "unitTests.py", line 106, in main
    modules]
  File "/usr/lib/python2.7/unittest/loader.py", line 91, in loadTestsFromName
    module = __import__('.'.join(parts_copy))
  File "/home/sekikn/repos/ambari-metrics/ambari-metrics-host-monitoring/src/test/python/core/TestHostInfo.py", line 24, in <module>
    from host_info import HostInfo
  File "/home/sekikn/repos/ambari-metrics/ambari-metrics-host-monitoring/src/main/python/core/host_info.py", line 25, in <module>
    import psutil
ImportError: No module named psutil
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.402 s
[INFO] Finished at: 2023-02-24T14:47:38+09:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:exec (python-test) on project ambari-metrics-host-monitoring: Command execution failed.: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
```

This is because [`src/main/python/core/__init__.py` assumes the psutil package is under src/main/python/psutil/build](https://github.com/apache/ambari-metrics/blob/release-2.0.0-rc0/ambari-metrics-host-monitoring/src/main/python/core/__init__.py#L24-L31), but [pom.xml uses another directory to build it](https://github.com/apache/ambari-metrics/blob/release-2.0.0-rc0/ambari-metrics-host-monitoring/pom.xml#L191-L194).

In addition, the core package of ambari-metrics-host-monitoring should be loaded before TestHostInfo.py so that the psutil package is loaded in advance.

## How was this patch tested?

Ran `mvn clean test -f ambari-metrics-host-monitoring/pom.xml` with this PR locally, as follows:

```
$ mvn clean test -f ambari-metrics-host-monitoring/pom.xml

...

Ran 19 tests in 1.022s

OK
----------------------------------------------------------------------
Total run:19
Total errors:0
Total failures:0
OK

...

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.675 s
[INFO] Finished at: 2023-02-24T15:02:03+09:00
[INFO] ------------------------------------------------------------------------
```