### PR TITLE
AMBARI-25866: Fix an unit test failure on ambari-metrics-kafka-sink

### DIFF
--- a/ambari-metrics-kafka-sink/src/test/java/org/apache/hadoop/metrics2/sink/kafka/KafkaTimelineMetricsReporterTest.java
+++ b/ambari-metrics-kafka-sink/src/test/java/org/apache/hadoop/metrics2/sink/kafka/KafkaTimelineMetricsReporterTest.java
@@ -27,6 +27,7 @@ import com.yammer.metrics.core.Metric;
 import com.yammer.metrics.core.MetricsRegistry;
 import com.yammer.metrics.core.Timer;
 import junit.framework.Assert;
+import kafka.metrics.KafkaYammerMetrics;
 import kafka.utils.VerifiableProperties;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
 import org.apache.hadoop.metrics2.sink.timeline.cache.TimelineMetricsCache;
@@ -51,7 +52,7 @@ import static org.powermock.api.easymock.PowerMock.verifyAll;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ Metrics.class, URL.class, OutputStream.class,
-  KafkaTimelineMetricsReporter.TimelineScheduledReporter.class })
+  KafkaTimelineMetricsReporter.TimelineScheduledReporter.class, KafkaYammerMetrics.class })
 @PowerMockIgnore({"javax.management.*", "org.apache.log4j.*", "org.slf4j.*"})
 public class KafkaTimelineMetricsReporterTest {
 
@@ -92,11 +93,11 @@ public class KafkaTimelineMetricsReporterTest {
 
   @Test
   public void testReporterStartStop() {
-    mockStatic(Metrics.class);
-    EasyMock.expect(Metrics.defaultRegistry()).andReturn(registry).times(2);
+    mockStatic(KafkaYammerMetrics.class);
+    EasyMock.expect(KafkaYammerMetrics.defaultRegistry()).andReturn(registry).times(2);
     TimelineMetricsCache timelineMetricsCache = getTimelineMetricsCache(kafkaTimelineMetricsReporter);
     kafkaTimelineMetricsReporter.setMetricsCache(timelineMetricsCache);
-    replay(Metrics.class, timelineMetricsCache);
+    replay(KafkaYammerMetrics.class, timelineMetricsCache);
     kafkaTimelineMetricsReporter.init(props);
     kafkaTimelineMetricsReporter.stopReporter();
     verifyAll();
@@ -104,11 +105,11 @@ public class KafkaTimelineMetricsReporterTest {
 
   @Test
   public void testReporterStartStopHttps() {
-    mockStatic(Metrics.class);
-    EasyMock.expect(Metrics.defaultRegistry()).andReturn(registry).times(2);
+    mockStatic(KafkaYammerMetrics.class);
+    EasyMock.expect(KafkaYammerMetrics.defaultRegistry()).andReturn(registry).times(2);
     TimelineMetricsCache timelineMetricsCache = getTimelineMetricsCache(kafkaTimelineMetricsReporter);
     kafkaTimelineMetricsReporter.setMetricsCache(timelineMetricsCache);
-    replay(Metrics.class, timelineMetricsCache);
+    replay(KafkaYammerMetrics.class, timelineMetricsCache);
 
     Properties properties = new Properties();
     properties.setProperty("zookeeper.connect", "localhost:2181");
@@ -133,12 +134,12 @@ public class KafkaTimelineMetricsReporterTest {
 
   @Test
   public void testMetricsExclusionPolicy() throws Exception {
-    mockStatic(Metrics.class);
-    EasyMock.expect(Metrics.defaultRegistry()).andReturn(registry).times(2);
+    mockStatic(KafkaYammerMetrics.class);
+    EasyMock.expect(KafkaYammerMetrics.defaultRegistry()).andReturn(registry).times(2);
     TimelineMetricsCache timelineMetricsCache = getTimelineMetricsCache(kafkaTimelineMetricsReporter);
     kafkaTimelineMetricsReporter.setMetricsCache(timelineMetricsCache);
 
-    replay(Metrics.class, timelineMetricsCache);
+    replay(KafkaYammerMetrics.class, timelineMetricsCache);
     kafkaTimelineMetricsReporter.init(props);
 
     Assert.assertTrue(kafkaTimelineMetricsReporter.isExcludedMetric("a.b.c"));


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
