### PR TITLE
AMBARI-25958: Ambari metrics returns Infinity when rate transformation is used

### DIFF
--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsService.java
@@ -363,7 +363,8 @@ public class HBaseTimelineMetricsService extends AbstractService implements Time
         if (diff < 0) {
           it.remove(); //Discard calculating rate when the metric counter has been reset.
         } else {
-          Double rate = isDiff ? diff : (diff / TimeUnit.MILLISECONDS.toSeconds(step));
+          double seconds = step / 1000.0;
+          Double rate = isDiff ? diff : (diff / seconds);
           timeValueEntry.setValue(rate);
         }
       } else {

--- a/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsServiceTest.java
+++ b/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/HBaseTimelineMetricsServiceTest.java
@@ -133,4 +133,19 @@ public class HBaseTimelineMetricsServiceTest {
     Assert.assertTrue(rates.containsValue(3.0));
     Assert.assertTrue(rates.containsValue(5.0));
   }
+
+  @Test
+  public void testRateCalculationShouldNotReturnInfinite() {
+    Map<Long, Double> metricValues = new TreeMap<>();
+    metricValues.put(1686721209272L, 5538.0);
+    metricValues.put(1686721219241L, 1750.0);
+    metricValues.put(1686721219272L, 5538.0);
+
+    // Calculate rate
+    Map<Long, Double> rates = HBaseTimelineMetricsService.updateValuesAsRate(new TreeMap<>(metricValues), false);
+    for (Map.Entry<Long, Double> entry :
+            rates.entrySet()) {
+      Assert.assertNotSame("rate transformation should not return Infinity", "Infinity", Double.toString(entry.getValue()));
+    }
+  }
 }


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?
Verified changes in existing cluster. Added UT to validate the fix.

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
