### PR TITLE
AMBARI-25962: Host apps metadata is not synced to other collectors when multiple collectors are installed

### DIFF
--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
@@ -200,7 +200,8 @@ public class TimelineMetricMetadataSync implements Runnable {
       Map<String, TimelineMetricHostMetadata> cachedData = cacheManager.getHostedAppsCache();
 
       for (Map.Entry<String, TimelineMetricHostMetadata> storeEntry : hostedAppsDataFromStore.entrySet()) {
-        if (!cachedData.containsKey(storeEntry.getKey())) {
+        if (!cachedData.containsKey(storeEntry.getKey()) ||
+                !cachedData.get(storeEntry.getKey()).getHostedApps().keySet().containsAll(storeEntry.getValue().getHostedApps().keySet())) {
           cachedData.put(storeEntry.getKey(), storeEntry.getValue());
         }
       }


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

Compare not only host but also list of apps associated with the host

## How was this patch tested?
Test the scenario mentioned the jira before and after the fix. Fix was verified on by applying the changes on existing cluster

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
