### PR TITLE
AMBARI-25963: Metrics metadata sync problem, accessing metrics which got created though other collector throws NPE

### DIFF
--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
@@ -422,6 +422,16 @@ public class TimelineMetricMetadataManager {
   }
 
   /**
+   * Add uuid to metrics metadata mapping.
+   *
+   * @param uuid        metrics uuid
+   * @param metadataKey metrics metadata key
+   */
+  public void addMetricsInUuidMap(byte[] uuid, TimelineMetricMetadataKey metadataKey) {
+    uuidKeyMap.put(new TimelineMetricUuid(uuid), metadataKey);
+  }
+
+  /**
    * Returns the UUID gen strategy.
    * @param configuration the config
    * @return the UUID generator of type org.apache.ambari.metrics.core.timeline.uuid.MetricUuidGenStrategy

--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
@@ -110,6 +110,7 @@ public class TimelineMetricMetadataSync implements Runnable {
       for (Map.Entry<TimelineMetricMetadataKey, TimelineMetricMetadata> metadataEntry : metadataFromStore.entrySet()) {
         if (!cachedMetadata.containsKey(metadataEntry.getKey())) {
           cachedMetadata.put(metadataEntry.getKey(), metadataEntry.getValue());
+          cacheManager.addMetricsInUuidMap(metadataEntry.getValue().getUuid(), metadataEntry.getKey());
         }
       }
     }

--- a/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/discovery/TestMetadataSync.java
+++ b/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/discovery/TestMetadataSync.java
@@ -18,6 +18,9 @@
 package org.apache.ambari.metrics.core.timeline.discovery;
 
 import junit.framework.Assert;
+import org.apache.ambari.metrics.core.timeline.aggregators.TimelineClusterMetric;
+import org.apache.ambari.metrics.core.timeline.uuid.MetricUuidGenStrategy;
+import org.apache.ambari.metrics.core.timeline.uuid.Murmur3HashUuidGenStrategy;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetricMetadata;
 import org.apache.ambari.metrics.core.timeline.PhoenixHBaseAccessor;
@@ -35,6 +38,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
 public class TestMetadataSync {
+  private  MetricUuidGenStrategy uuidGenStrategy = new Murmur3HashUuidGenStrategy();
   @Test
   public void testRefreshMetadataOnWrite() throws Exception {
     Configuration configuration = createNiceMock(Configuration.class);
@@ -42,8 +46,10 @@ public class TestMetadataSync {
 
     final TimelineMetricMetadata testMetadata1 = new TimelineMetricMetadata(
       "m1", "a1", null, "", GAUGE.name(), System.currentTimeMillis(), true, false);
+    setMetricsUuid(testMetadata1);
     final TimelineMetricMetadata testMetadata2 = new TimelineMetricMetadata(
       "m2", "a2", null, "", GAUGE.name(), System.currentTimeMillis(), true, false);
+    setMetricsUuid(testMetadata2);
 
     Map<TimelineMetricMetadataKey, TimelineMetricMetadata> metadata =
       new HashMap<TimelineMetricMetadataKey, TimelineMetricMetadata>() {{
@@ -80,6 +86,9 @@ public class TestMetadataSync {
     Assert.assertEquals(2, metadata.size());
     Assert.assertTrue(metadata.containsKey(new TimelineMetricMetadataKey("m1", "a1", null)));
     Assert.assertTrue(metadata.containsKey(new TimelineMetricMetadataKey("m2", "a2", null)));
+    // Check if synced metrics can be found with uuid
+    Assert.assertNotNull("metrics not found with testMetadata1 uuid", metadataManager.getMetricFromUuid(testMetadata1.getUuid()));
+    Assert.assertNotNull("metrics not found with testMetadata2 uuid", metadataManager.getMetricFromUuid(testMetadata2.getUuid()));
 
     hostedApps = metadataManager.getHostedAppsCache();
     Assert.assertEquals(2, hostedApps.size());
@@ -91,6 +100,12 @@ public class TestMetadataSync {
     Assert.assertEquals(1, hostedInstances.get("i1").size());
     Assert.assertEquals(2, hostedInstances.get("i2").size());
 
+  }
+
+  private void setMetricsUuid(TimelineMetricMetadata tmm) {
+    byte[] uuidBytes = uuidGenStrategy.computeUuid(new TimelineClusterMetric(tmm.getMetricName(), tmm.getAppId(),
+            tmm.getInstanceId(), tmm.getSeriesStartTime()), TimelineMetricMetadataManager.TIMELINE_METRIC_UUID_LENGTH);
+    tmm.setUuid(uuidBytes);
   }
 
   @Test


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

When metrics are synced from other collectors, update the uuid metrics metadata map as well.

## How was this patch tested?

Tested the scenario mentioned the jira before and after the fix. Fix was verified by applying the changes on existing cluster

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
