### PR TITLE
AMBARI-25998: Host uuid is not getting synced to other collectors, causing NPE while accessing metric

### DIFF
--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataManager.java
@@ -432,6 +432,17 @@ public class TimelineMetricMetadataManager {
   }
 
   /**
+   * Add host with uuid into uuidHostMap
+   *
+   * @param hostName       host name
+   * @param tmHostMetadata TimelineMetricHostMetadata
+   */
+  public void addHostInUuidHostMap(String hostName, TimelineMetricHostMetadata tmHostMetadata) {
+    TimelineMetricUuid timelineMetricUuid = new TimelineMetricUuid(tmHostMetadata.getUuid());
+    uuidHostMap.put(timelineMetricUuid, hostName);
+  }
+
+  /**
    * Returns the UUID gen strategy.
    * @param configuration the config
    * @return the UUID generator of type org.apache.ambari.metrics.core.timeline.uuid.MetricUuidGenStrategy

--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataSync.java
@@ -201,8 +201,12 @@ public class TimelineMetricMetadataSync implements Runnable {
       Map<String, TimelineMetricHostMetadata> cachedData = cacheManager.getHostedAppsCache();
 
       for (Map.Entry<String, TimelineMetricHostMetadata> storeEntry : hostedAppsDataFromStore.entrySet()) {
-        if (!cachedData.containsKey(storeEntry.getKey()) ||
-                !cachedData.get(storeEntry.getKey()).getHostedApps().keySet().containsAll(storeEntry.getValue().getHostedApps().keySet())) {
+        if (!cachedData.containsKey(storeEntry.getKey())) {
+          // New host is being synced
+          cacheManager.addHostInUuidHostMap(storeEntry.getKey(), storeEntry.getValue());
+          cachedData.put(storeEntry.getKey(), storeEntry.getValue());
+        } else if (!cachedData.get(storeEntry.getKey()).getHostedApps().keySet().containsAll(storeEntry.getValue().getHostedApps().keySet())) {
+          // host apps are being synced
           cachedData.put(storeEntry.getKey(), storeEntry.getValue());
         }
       }

--- a/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/discovery/TestMetadataSync.java
+++ b/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/core/timeline/discovery/TestMetadataSync.java
@@ -21,11 +21,13 @@ import junit.framework.Assert;
 import org.apache.ambari.metrics.core.timeline.aggregators.TimelineClusterMetric;
 import org.apache.ambari.metrics.core.timeline.uuid.MetricUuidGenStrategy;
 import org.apache.ambari.metrics.core.timeline.uuid.Murmur3HashUuidGenStrategy;
+import org.apache.ambari.metrics.core.timeline.uuid.TimelineMetricUuid;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetricMetadata;
 import org.apache.ambari.metrics.core.timeline.PhoenixHBaseAccessor;
 import org.junit.Test;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -176,5 +178,41 @@ public class TestMetadataSync {
     Assert.assertEquals(1, hostedApps.size());
     // After other collector's host app data is synced
     Assert.assertEquals("Host app list is not synced properly",3, hostedApps.get("host1").getHostedApps().size());
+  }
+
+  @Test
+  public void testSyncHostUuid() throws Exception {
+    Configuration configuration = createNiceMock(Configuration.class);
+    PhoenixHBaseAccessor hBaseAccessor = createNiceMock(PhoenixHBaseAccessor.class);
+    TimelineMetricHostMetadata hostMeta = new TimelineMetricHostMetadata(new HashSet<>(Arrays.asList("app1", "app2", "app3")));
+    byte[] hostUuid = uuidGenStrategy.computeUuid("host1", TimelineMetricMetadataManager.HOSTNAME_UUID_LENGTH);
+    hostMeta.setUuid(hostUuid);
+    Map<String, TimelineMetricHostMetadata> hostedApps = new HashMap<String, TimelineMetricHostMetadata>() {{
+      put("host1", hostMeta);
+    }};
+
+    expect(configuration.get("timeline.metrics.service.operation.mode")).andReturn("distributed");
+    expect(hBaseAccessor.getHostedAppsMetadata()).andReturn(hostedApps);
+    replay(configuration, hBaseAccessor);
+
+    TimelineMetricMetadataManager metadataManager = new TimelineMetricMetadataManager(configuration, hBaseAccessor);
+    metadataManager.markSuccessOnSyncHostedAppsMetadata();
+    hostedApps = metadataManager.getHostedAppsCache();
+    // Before other collector's host app data is synced
+    Assert.assertNull(hostedApps.get("host1"));
+
+    metadataManager.metricMetadataSync = new TimelineMetricMetadataSync(metadataManager);
+    metadataManager.metricMetadataSync.run();
+
+    verify(configuration, hBaseAccessor);
+
+    hostedApps = metadataManager.getHostedAppsCache();
+    Assert.assertEquals(1, hostedApps.size());
+    Field field = TimelineMetricMetadataManager.class.getDeclaredField("uuidHostMap");
+    field.setAccessible(true);
+
+    Map<TimelineMetricUuid, String> uuidHostMap = (Map<TimelineMetricUuid, String>) field.get(metadataManager);
+    TimelineMetricUuid timelineMetricUuid = new TimelineMetricUuid(hostUuid);
+    Assert.assertTrue("Host uuid was not synced",uuidHostMap.containsKey(timelineMetricUuid));
   }
 }


### PR DESCRIPTION

<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

When new host is synced from other collector, cache host uuid also

## How was this patch tested?
Written UT to test this functionality. Before change UT is failing, after fix UT is passing.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
