### PR TITLE
[AMBARI-26027]:fix no data is available for monitoring indicators of components…

### DIFF
--- a/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataKey.java
+++ b/ambari-metrics-timelineservice/src/main/java/org/apache/ambari/metrics/core/timeline/discovery/TimelineMetricMetadataKey.java
@@ -57,14 +57,14 @@ public class TimelineMetricMetadataKey {
     TimelineMetricMetadataKey that = (TimelineMetricMetadataKey) o;
 
     if (!metricName.equals(that.metricName)) return false;
-    if (!appId.equals(that.appId)) return false;
+    if (!appId.toLowerCase().equals(that.appId.toLowerCase())) return false;
     return (StringUtils.isNotEmpty(instanceId) ? instanceId.equals(that.instanceId) : StringUtils.isEmpty(that.instanceId));
   }
 
   @Override
   public int hashCode() {
     int result = metricName.hashCode();
-    result = 31 * result + (appId != null ? appId.hashCode() : 0);
+    result = 31 * result + (appId != null ? appId.toLowerCase().hashCode() : 0);
     result = 31 * result + (instanceId != null ? instanceId.hashCode() : 0);
     return result;
   }


### PR DESCRIPTION
… such as hdfs and yarn on the web page

<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

i have changed the java file(ambari-metrics-timelineservice\src\main\java\org\apache\ambari\metrics\core\timeline\discovery\TimelineMetricMetadataKey.java),there are two methods were modified: equals and hashcode

## How was this patch tested?

i run this command （mvn clean package -Dbuild-rpm -DskipTests -Djdk.version="1.8" -T 1C）to package ambari-metrics project, and replace ambari-metrics-timelineservice.jar in the /usr/lib/ambari-metrics-collector/ directory,then restart ambari-web

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
