### PR TITLE
[AMBARI-26095] Upgrade Grafana version 9.5.5 to 11.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
     <hadoop.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/hadoop-3.3.4.tar.gz</hadoop.tar>
     <hadoop.folder>hadoop-3.3.4</hadoop.folder>
     <hadoop.version>3.3.4</hadoop.version>
-    <grafana.folder>grafana-9.5.6</grafana.folder>
-    <grafana.tar>https://dl.grafana.com/oss/release/grafana-9.5.6.linux-amd64.tar.gz</grafana.tar>
+    <grafana.folder>grafana-v11.1.4</grafana.folder>
+    <grafana.tar>https://dl.grafana.com/oss/release/grafana-11.1.4.linux-amd64.tar.gz</grafana.tar>
     <phoenix.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/phoenix-hbase-2.4-5.1.2-bin.tar.gz</phoenix.tar>
     <phoenix.folder>phoenix-hbase-2.4-5.1.2-bin</phoenix.folder>
     <resmonitor.install.dir>/usr/lib/python3.9/site-packages/resource_monitoring</resmonitor.install.dir>


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?
Upgrade Grafana version 9.5.5 to 11.1.4 to fix CVE-2024-1442

(Please fill in changes proposed in this fix)

## How was this patch tested?
Tested it by installing a local cluster. All metrics are coming. Check images on https://issues.apache.org/jira/browse/AMBARI-26095

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
