### PR TITLE
AMBARI-26123：Ambari-metrics build failed

### DIFF
--- a/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics-timelineservice/pom.xml
@@ -49,7 +49,6 @@
             <configuration>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
               <includeScope>compile</includeScope>
-              <excludeScope>test</excludeScope>
               <excludeArtifactIds>jasper-runtime,jasper-compiler
               </excludeArtifactIds>
             </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?
ambari-metrics build failed, the error massage is:
![微信图片_20240904182022](https://issues.apache.org/jira/secure/attachment/13071300/13071300_%E5%BE%AE%E4%BF%A1%E5%9B%BE%E7%89%87_20240904182022.png)
The high version of maven-dependency-plugin  do not support "includeScope" and "excludeScope"  label at the same time.

## How was this patch tested?
build ambari-metrics project:
mvn clean package -Dbuild-rpm -Drat.skip=true -DskipTests -Dmaven.test.skip=true
