### PR TITLE
AMBARI-26131:Fix ambari-metrics-collector service check failed and resolve jar conflict problem

### DIFF
--- a/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics-assembly/pom.xml
@@ -220,8 +220,6 @@
                             <exclude>*tests.jar</exclude>
                             <exclude>findbugs*.jar</exclude>
                             <exclude>jdk.tools*.jar</exclude>
-                            <!--exclude>hadoop*.jar</exclude>
-                            <exclude>hbase*.jar</exclude-->
                           </excludes>
                         </source>
                         <source>
@@ -229,13 +227,6 @@
                             ${collector.dir}/target/ambari-metrics-timelineservice-${project.version}.jar
                           </location>
                         </source>
-                        <!--source>
-                          <location>${collector.dir}/target/embedded/${hbase.folder}/lib</location>
-                          <includes>
-                            <include>hadoop*.jar</include>
-                            <include>hbase*.jar</include>
-                          </includes>
-                        </source-->
                       </sources>
                     </mapping>
                     <mapping>

--- a/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics-assembly/pom.xml
@@ -220,8 +220,8 @@
                             <exclude>*tests.jar</exclude>
                             <exclude>findbugs*.jar</exclude>
                             <exclude>jdk.tools*.jar</exclude>
-                            <exclude>hadoop*.jar</exclude>
-                            <exclude>hbase*.jar</exclude>
+                            <!--exclude>hadoop*.jar</exclude>
+                            <exclude>hbase*.jar</exclude-->
                           </excludes>
                         </source>
                         <source>
@@ -229,13 +229,13 @@
                             ${collector.dir}/target/ambari-metrics-timelineservice-${project.version}.jar
                           </location>
                         </source>
-                        <source>
+                        <!--source>
                           <location>${collector.dir}/target/embedded/${hbase.folder}/lib</location>
                           <includes>
                             <include>hadoop*.jar</include>
                             <include>hbase*.jar</include>
                           </includes>
-                        </source>
+                        </source-->
                       </sources>
                     </mapping>
                     <mapping>

--- a/ambari-metrics-common/pom.xml
+++ b/ambari-metrics-common/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -103,7 +103,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>28.0-jre</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>

--- a/ambari-metrics-flume-sink/pom.xml
+++ b/ambari-metrics-flume-sink/pom.xml
@@ -141,7 +141,6 @@ limitations under the License.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/ambari-metrics-hadoop-sink/pom.xml
+++ b/ambari-metrics-hadoop-sink/pom.xml
@@ -125,7 +125,7 @@ limitations under the License.
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.1</version>
+      <version>2.8.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/ambari-metrics-host-aggregator/pom.xml
+++ b/ambari-metrics-host-aggregator/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
         <dependency>
               <groupId>org.apache.ambari</groupId>

--- a/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics-timelineservice/pom.xml
@@ -317,6 +317,54 @@
           <artifactId>hadoop-annotations</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-mapreduce-client-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-mapreduce</artifactId>
+          <groupId>org.apache.hbase</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-hadoop-compat</artifactId>
+          <groupId>org.apache.hbase</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-hadoop2-compat</artifactId>
+          <groupId>org.apache.hbase</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-common</artifactId>
+          <groupId>org.apache.hbase</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-protocol</artifactId>
+          <groupId>org.apache.hbase</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-protocol-shaded</artifactId>
+          <groupId>org.apache.hbase</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-metrics-api</artifactId>
+          <groupId>org.apache.hbase</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-zookeeper</artifactId>
+          <groupId>org.apache.hbase</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-shaded-miscellaneous</artifactId>
+          <groupId>org.apache.hbase.thirdparty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hbase-shaded-protobuf</artifactId>
+          <groupId>org.apache.hbase.thirdparty</groupId>
+        </exclusion>
+        <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </exclusion>
@@ -343,6 +391,62 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-distcp</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-mapreduce</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-metrics</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>sqlline</groupId>
+      <artifactId>sqlline</artifactId>
+      <version>1.9.0</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix-hbase-compat-2.4.1</artifactId>
@@ -530,7 +634,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>28.0-jre</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -545,7 +648,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -793,6 +896,10 @@
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-minicluster</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,19 +40,19 @@
     <slf4j.version>2.0.0</slf4j.version>
     <zookeeper.version>3.7.2</zookeeper.version>
     <kafka.version>2.8.2</kafka.version>
-    <phoenix.version>5.1.2</phoenix.version>
+    <phoenix.version>5.1.3</phoenix.version>
     <hbase.version>2.4.17</hbase.version>
     <curator.version>4.2.0</curator.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
-    <hbase.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/hbase-2.4.17-bin.tar.gz</hbase.tar>
+    <hbase.tar>https://archive.apache.org/dist/hbase/2.4.17/hbase-2.4.17-bin.tar.gz</hbase.tar>
     <hbase.folder>hbase-2.4.17</hbase.folder>
-    <hadoop.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/hadoop-3.3.6.tar.gz</hadoop.tar>
+    <hadoop.tar>https://archive.apache.org/dist/hadoop/common/hadoop-3.3.6/hadoop-3.3.6.tar.gz</hadoop.tar>
     <hadoop.folder>hadoop-3.3.6</hadoop.folder>
     <hadoop.version>3.3.6</hadoop.version>
     <grafana.folder>grafana-9.5.6</grafana.folder>
     <grafana.tar>https://dl.grafana.com/oss/release/grafana-9.5.6.linux-amd64.tar.gz</grafana.tar>
-    <phoenix.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/phoenix-hbase-2.4-5.1.2-bin.tar.gz</phoenix.tar>
-    <phoenix.folder>phoenix-hbase-2.4-5.1.2-bin</phoenix.folder>
+    <phoenix.tar>https://archive.apache.org/dist/phoenix/phoenix-5.1.3/phoenix-hbase-2.4-5.1.3-bin.tar.gz</phoenix.tar>
+    <phoenix.folder>phoenix-hbase-2.4-5.1.3-bin</phoenix.folder>
     <resmonitor.install.dir>/usr/lib/python3.9/site-packages/resource_monitoring</resmonitor.install.dir>
     <powermock.version>1.6.2</powermock.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,17 +38,17 @@
     <python.ver>python3 &gt;= 3.0</python.ver>
     <deb.python.ver>python3 (&gt;= 3.0)</deb.python.ver>
     <slf4j.version>2.0.0</slf4j.version>
-    <zookeeper.version>3.5.9</zookeeper.version>
-    <kafka.version>2.8.1</kafka.version>
+    <zookeeper.version>3.7.2</zookeeper.version>
+    <kafka.version>2.8.2</kafka.version>
     <phoenix.version>5.1.2</phoenix.version>
-    <hbase.version>2.4.13</hbase.version>
+    <hbase.version>2.4.17</hbase.version>
     <curator.version>4.2.0</curator.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
-    <hbase.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/hbase-2.4.13-bin.tar.gz</hbase.tar>
-    <hbase.folder>hbase-2.4.13</hbase.folder>
-    <hadoop.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/hadoop-3.3.4.tar.gz</hadoop.tar>
-    <hadoop.folder>hadoop-3.3.4</hadoop.folder>
-    <hadoop.version>3.3.4</hadoop.version>
+    <hbase.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/hbase-2.4.17-bin.tar.gz</hbase.tar>
+    <hbase.folder>hbase-2.4.17</hbase.folder>
+    <hadoop.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/hadoop-3.3.6.tar.gz</hadoop.tar>
+    <hadoop.folder>hadoop-3.3.6</hadoop.folder>
+    <hadoop.version>3.3.6</hadoop.version>
     <grafana.folder>grafana-9.5.6</grafana.folder>
     <grafana.tar>https://dl.grafana.com/oss/release/grafana-9.5.6.linux-amd64.tar.gz</grafana.tar>
     <phoenix.tar>http://repo.bigtop.apache.org.s3.amazonaws.com/bigtop-stack-binary/3.2.0/centos-7/x86_64/phoenix-hbase-2.4-5.1.2-bin.tar.gz</phoenix.tar>
@@ -133,7 +133,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>28.0-jre</version>
+        <version>32.1.1-jre</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?
After ambari-metrics-collector installed, i find the service check is failed. So i check the service port 6188 on host. The port is listened but access the url is failed return 500 (http://x.x.x.x:6188/ws/v1/timeline/metrics/livenodes) 
Finally i find warn log about ambari-metrics-collector.It seems to be caused by  jar conflict
![微信图片_20240909143358](https://issues.apache.org/jira/secure/attachment/13071438/13071438_%E5%BE%AE%E4%BF%A1%E5%9B%BE%E7%89%87_20240909143358.png)

At the same time, I upgraded some jar versions：
to solve the CVE problem：
    &nbsp;&nbsp;&nbsp;&nbsp;1.upgrade commons-io to 2.8.0
    &nbsp;&nbsp;&nbsp;&nbsp;2.upgrade guava to 32.1.1-jre
adapt to bigtop3 and modify tar.gz download url：
    &nbsp;&nbsp;&nbsp;&nbsp;1.upgrade kafka to 2.8.2
    &nbsp;&nbsp;&nbsp;&nbsp;2.upgrade zookeeper to 3.7.2
    &nbsp;&nbsp;&nbsp;&nbsp;3.upgrade hbase to 2.4.17
    &nbsp;&nbsp;&nbsp;&nbsp;4.upgrade hadoop to 3.3.6
    &nbsp;&nbsp;&nbsp;&nbsp;5.upgrade phoenix to 2.4-5.1.3
add missing jar：
    &nbsp;&nbsp;&nbsp;&nbsp;1.sqlline
## How was this patch tested?
1.build ambari-metrics
 mvn clean package -Dbuild-rpm -Drat.skip=true -DskipTests -Dmaven.test.skip=true
![微信图片_20240909194248](https://github.com/user-attachments/assets/2fae38d3-08fb-479b-853e-7ad80268bdd4)
2.install ambari-metrics
![微信图片_20240909194351](https://github.com/user-attachments/assets/fa2211d7-900e-45f1-8fd7-39475a9bdec4)

