### PR TITLE
AMBARI-26142: JDK17 support for Ambari-metrics

### DIFF
--- a/.github/workflows/ambari.yml
+++ b/.github/workflows/ambari.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 8
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 8
+        java-version: 17
         distribution: temurin
         cache: maven
     - name: Install Kerberos development libraries

--- a/ambari-metrics-assembly/pom.xml
+++ b/ambari-metrics-assembly/pom.xml
@@ -964,7 +964,7 @@
                 <data>
                   <src>${collector.dir}/target/lib</src>
                   <type>directory</type>
-                  <includes>phoenix*.jar,antlr*.jar,re2j*.jar,failureaccess*.jar,guava-28*.jar,stax2-api*.jar,woodstox-core*.jar,hadoop-annotations*.jar,hadoop-auth*.jar,hadoop-common*.jar,commons-configuration2*.jar,hadoop-yarn-api-*.jar,hadoop-yarn-client-*.jar,hadoop-yarn-common-*.jar,hadoop-yarn-registry-*.jar,hadoop-yarn-server-applicationhistoryservice-*.jar,hadoop-yarn-server-common-*.jar,hadoop-yarn-server-nodemanager-*.jar,hadoop-yarn-server-resourcemanager-*.jar,hadoop-yarn-server-timelineservice-*.jar,hadoop-yarn-server-web-proxy-*.jar</includes>
+                  <includes>phoenix*.jar,antlr*.jar,re2j*.jar,failureaccess*.jar,guava-32*.jar,stax2-api*.jar,woodstox-core*.jar,hadoop-annotations*.jar,hadoop-auth*.jar,hadoop-common*.jar,commons-configuration2*.jar,hadoop-yarn-api-*.jar,hadoop-yarn-client-*.jar,hadoop-yarn-common-*.jar,hadoop-yarn-registry-*.jar,hadoop-yarn-server-applicationhistoryservice-*.jar,hadoop-yarn-server-common-*.jar,hadoop-yarn-server-nodemanager-*.jar,hadoop-yarn-server-resourcemanager-*.jar,hadoop-yarn-server-timelineservice-*.jar,hadoop-yarn-server-web-proxy-*.jar</includes>
                   <mapper>
                     <type>perm</type>
                     <filemode>644</filemode>

--- a/ambari-metrics-common/pom.xml
+++ b/ambari-metrics-common/pom.xml
@@ -31,7 +31,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
       </plugin>
       <plugin>
         <groupId>org.vafer</groupId>
@@ -56,7 +56,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.5.1</version>
         <executions>
           <!-- Run shade goal on package phase -->
           <execution>
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>28.0-jre</version>
+      <version>32.1.3-jre</version>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
@@ -155,6 +155,11 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.2</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/ambari-metrics-flume-sink/pom.xml
+++ b/ambari-metrics-flume-sink/pom.xml
@@ -54,7 +54,7 @@ limitations under the License.
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
       </plugin>
       <plugin>
         <groupId>com.github.goldin</groupId>
@@ -141,7 +141,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>32.1.3-jre</version>
     </dependency>
   </dependencies>
 </project>

--- a/ambari-metrics-hadoop-sink/pom.xml
+++ b/ambari-metrics-hadoop-sink/pom.xml
@@ -60,7 +60,7 @@ limitations under the License.
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
       </plugin>
       <plugin>
         <groupId>com.github.goldin</groupId>

--- a/ambari-metrics-host-aggregator/pom.xml
+++ b/ambari-metrics-host-aggregator/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>32.1.3-jre</version>
         </dependency>
         <dependency>
               <groupId>org.apache.ambari</groupId>
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.5.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>

--- a/ambari-metrics-host-aggregator/src/test/java/org/apache/hadoop/metrics2/host/aggregator/AggregatorWebServiceTest.java
+++ b/ambari-metrics-host-aggregator/src/test/java/org/apache/hadoop/metrics2/host/aggregator/AggregatorWebServiceTest.java
@@ -31,16 +31,14 @@ import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 import org.codehaus.jackson.jaxrs.JacksonJaxbJsonProvider;
 import org.junit.Test;
 
-
 import javax.ws.rs.core.MediaType;
 
 import java.util.Collection;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-
 
 public class AggregatorWebServiceTest extends JerseyTest {
+
     public AggregatorWebServiceTest() {
         super(new WebAppDescriptor.Builder(
                 "org.apache.hadoop.metrics2.host.aggregator")
@@ -74,11 +72,9 @@ public class AggregatorWebServiceTest extends JerseyTest {
         assertEquals(404, response.getStatus());
     }
 
-
     @Test
     public void testMetricsPost() {
         TimelineMetricsHolder timelineMetricsHolder = TimelineMetricsHolder.getInstance();
-
         timelineMetricsHolder.extractMetricsForAggregationPublishing();
         timelineMetricsHolder.extractMetricsForRawPublishing();
 

--- a/ambari-metrics-host-monitoring/pom.xml
+++ b/ambari-metrics-host-monitoring/pom.xml
@@ -53,7 +53,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/ambari-metrics-kafka-sink/pom.xml
+++ b/ambari-metrics-kafka-sink/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
       </plugin>
       <plugin>
         <groupId>com.github.goldin</groupId>

--- a/ambari-metrics-storm-sink/pom.xml
+++ b/ambari-metrics-storm-sink/pom.xml
@@ -38,7 +38,7 @@ limitations under the License.
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
       </plugin>
       <plugin>
         <groupId>com.github.goldin</groupId>
@@ -54,7 +54,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.5.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics-timelineservice/pom.xml
@@ -57,7 +57,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -216,7 +216,6 @@
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <forkMode>always</forkMode>
-          <argLine>-XX:-UseSplitVerifier</argLine>
           <!-- Each profile in the top-level pom.xml defines which test group categories to run. -->
           <groups>${testcase.groups}</groups>
         </configuration>
@@ -524,7 +523,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>28.0-jre</version>
+      <version>32.1.3-jre</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -662,6 +661,12 @@
           <artifactId>jackson-databind</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-server-applicationhistoryservice</artifactId>
+      <version>${hadoop.version}</version>
     </dependency>
 
     <!-- 'mvn dependency:analyze' fails to detect use of this dependency -->

--- a/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/webapp/TestTimelineWebServices.java
+++ b/ambari-metrics-timelineservice/src/test/java/org/apache/ambari/metrics/webapp/TestTimelineWebServices.java
@@ -25,8 +25,10 @@ import javax.ws.rs.core.MediaType;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 import org.apache.ambari.metrics.core.timeline.TestTimelineMetricStore;
 import org.apache.ambari.metrics.core.timeline.TimelineMetricStore;
+import org.apache.hadoop.metrics2.sink.timeline.TimelineMetrics;
 import org.apache.hadoop.yarn.webapp.GenericExceptionHandler;
 import org.apache.hadoop.yarn.webapp.YarnJacksonJaxbJsonProvider;
+
 import org.junit.Test;
 
 import com.google.inject.Guice;
@@ -75,24 +77,24 @@ public class TestTimelineWebServices extends JerseyTest {
 
   public TestTimelineWebServices() {
     super(new WebAppDescriptor.Builder(
-      "org.apache.ambari.metrics.webapp")
-      .contextListenerClass(GuiceServletConfig.class)
-      .filterClass(com.google.inject.servlet.GuiceFilter.class)
-      .contextPath("jersey-guice-filter")
-      .servletPath("/")
-      .clientConfig(new DefaultClientConfig(YarnJacksonJaxbJsonProvider.class))
-      .build());
+            "org.apache.ambari.metrics.webapp")
+            .contextListenerClass(GuiceServletConfig.class)
+            .filterClass(com.google.inject.servlet.GuiceFilter.class)
+            .contextPath("jersey-guice-filter")
+            .servletPath("/")
+            .clientConfig(new DefaultClientConfig(YarnJacksonJaxbJsonProvider.class))
+            .build());
   }
 
   @Test
   public void testAbout() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
-      .accept(MediaType.APPLICATION_JSON)
-      .get(ClientResponse.class);
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getType());
     TimelineWebServices.AboutInfo about =
-      response.getEntity(TimelineWebServices.AboutInfo.class);
+            response.getEntity(TimelineWebServices.AboutInfo.class);
     Assert.assertNotNull(about);
     Assert.assertEquals("AMS API", about.getAbout());
   }
@@ -109,9 +111,9 @@ public class TestTimelineWebServices extends JerseyTest {
   public void testGetMetrics() throws Exception {
     WebResource r = resource();
     ClientResponse response = r.path("ws").path("v1").path("timeline")
-      .path("metrics").queryParam("metricNames", "cpu_user").queryParam("precision", "seconds")
-      .accept(MediaType.APPLICATION_JSON)
-      .get(ClientResponse.class);
+            .path("metrics").queryParam("metricNames", "cpu_user").queryParam("precision", "seconds")
+            .accept(MediaType.APPLICATION_JSON)
+            .get(ClientResponse.class);
     assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getType());
     verifyMetrics(response.getEntity(TimelineMetrics.class));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
     <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
     <skipPythonTests>false</skipPythonTests>
+    <jersey.version>2.41</jersey.version>
     <release.version>1</release.version>
   </properties>
   <distributionManagement>
@@ -133,7 +134,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>28.0-jre</version>
+        <version>32.1.3-jre</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -169,9 +170,20 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19</version>
+        <version>3.2.5</version>
         <configuration>
           <skip>${skipSurefireTests}</skip>
+          <argLine>
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens java.management/java.lang.management=ALL-UNNAMED
+            --add-opens java.base/java.io=ALL-UNNAMED
+            --add-opens java.base/java.nio=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.util.regex=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens java.base/java.net=ALL-UNNAMED
+          </argLine>
 
           <!-- Each profile in the top-level pom.xml defines which test group categories to run. -->
           <groups>${testcase.groups}</groups>
@@ -179,10 +191,10 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
[AMBARI-26142] JDK17 support for Ambari-metrics

<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?
upgrade maven-compiler-plugin to 3.5
maven-shade-plugin to 3.5.1
guava to 32.1.3-jre
maven-surefire-plugin  to 3.2.5
JDK to 17
API changes
tests cases modified

(Please fill in changes proposed in this fix)

## How was this patch tested?
TESTING is pending.

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
