### PR TITLE
AMBARI-26264. Disable releases for apache-snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,14 +80,12 @@
   </distributionManagement>
   <repositories>
     <repository>
-      <id>apache-releases</id>
-      <name>releases</name>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-    </repository>
-    <repository>
       <id>apache-snapshots</id>
       <name>snapshots</name>
       <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </repository>
   </repositories>
   <dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Problem: [build](https://github.com/apache/ambari-metrics/actions/runs/11707520404/job/32845254675#step:6:486) tries to download release artifacts from `apache-snapshots` repo, and non-Apache artifacts from `apache-releases` repo.

```
[INFO] Downloading from apache-releases: https://repository.apache.org/content/repositories/releases/com/google/guava/guava/28.0-jre/guava-28.0-jre.pom
[INFO] Downloading from apache-snapshots: https://repository.apache.org/content/repositories/snapshots/com/google/guava/guava/28.0-jre/guava-28.0-jre.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/28.0-jre/guava-28.0-jre.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/28.0-jre/guava-28.0-jre.pom (8.7 kB at 513 kB/s)
```

Fix:
- disable release artifacts in `apache-snapshots`
- remove `apache-releases` repo, use `central` (inherited) instead

https://issues.apache.org/jira/browse/AMBARI-26264

## How was this patch tested?

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
...
[INFO] --- toolbox:0.6.0:list-repositories (default-cli) @ ambari-metrics ---
[INFO] Remote repositories used by project org.apache.ambari:ambari-metrics:pom:3.1.0-SNAPSHOT.
[INFO]  * central (https://repo.maven.apache.org/maven2/, default, releases)
[INFO]    First introduced on root
[INFO]  * apache-snapshots (https://repository.apache.org/content/repositories/snapshots, default, snapshots)
[INFO]    First introduced on root
```

Local build.