### PR TITLE
AMBARI-26313: Change metrics names in grafana dashboards as per the GC used in JDK17

### DIFF
--- a/ambari-metrics-timelineservice/conf/unix/amshbase_metrics_whitelist
+++ b/ambari-metrics-timelineservice/conf/unix/amshbase_metrics_whitelist
@@ -5,11 +5,11 @@ jvm.Master.JvmMetrics.ThreadsTerminated
 jvm.Master.JvmMetrics.ThreadsTimedWaiting
 jvm.Master.JvmMetrics.ThreadsWaiting
 jvm.RegionServer.JvmMetrics.GcCount
-jvm.RegionServer.JvmMetrics.GcCountConcurrentMarkSweep
-jvm.RegionServer.JvmMetrics.GcCountParNew
+jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation
 jvm.RegionServer.JvmMetrics.GcTimeMillis
-jvm.RegionServer.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.RegionServer.JvmMetrics.GcTimeMillisParNew
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation
 jvm.RegionServer.JvmMetrics.MemHeapCommittedM
 jvm.RegionServer.JvmMetrics.MemHeapMaxM
 jvm.RegionServer.JvmMetrics.MemHeapUsedM

--- a/ambari-metrics-timelineservice/conf/unix/metrics_whitelist
+++ b/ambari-metrics-timelineservice/conf/unix/metrics_whitelist
@@ -202,12 +202,12 @@ io.IOMetrics.PercentileDecodingTime_30s99thPercentileLatency
 ipc.client.org.apache.hadoop.ipc.DecayRpcScheduler.Caller(*).Priority
 ipc.client.org.apache.hadoop.ipc.DecayRpcScheduler.Caller(*).Volume
 jvm.JvmMetrics.GcCount
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
-jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcCountG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Young Generation
 jvm.JvmMetrics.GcNumWarnThresholdExceeded
 jvm.JvmMetrics.GcTimeMillis
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
 jvm.JvmMetrics.GcTotalExtraSleepTime
 jvm.JvmMetrics.LogError
 jvm.JvmMetrics.LogFatal
@@ -234,11 +234,11 @@ jvm.Master.JvmMetrics.ThreadsTerminated
 jvm.Master.JvmMetrics.ThreadsTimedWaiting
 jvm.Master.JvmMetrics.ThreadsWaiting
 jvm.RegionServer.JvmMetrics.GcCount
-jvm.RegionServer.JvmMetrics.GcCountConcurrentMarkSweep
-jvm.RegionServer.JvmMetrics.GcCountParNew
+jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation
 jvm.RegionServer.JvmMetrics.GcTimeMillis
-jvm.RegionServer.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.RegionServer.JvmMetrics.GcTimeMillisParNew
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation
 jvm.RegionServer.JvmMetrics.MemHeapCommittedM
 jvm.RegionServer.JvmMetrics.MemHeapMaxM
 jvm.RegionServer.JvmMetrics.MemHeapUsedM
@@ -253,10 +253,10 @@ jvm.RegionServer.JvmMetrics.ThreadsTimedWaiting
 jvm.RegionServer.JvmMetrics.ThreadsWaiting
 jvm.daemon_thread_count
 jvm.file_descriptor_usage
-jvm.gc.ConcurrentMarkSweep.count
-jvm.gc.ConcurrentMarkSweep.time
-jvm.gc.ParNew.count
-jvm.gc.ParNew.time
+jvm.gc.G1 Old Generation.count
+jvm.gc.G1 Old Generation.time
+jvm.gc.G1 Young Generation.count
+jvm.gc.G1 Young Generation.time
 jvm.heap_usage
 jvm.memory.heap.committed
 jvm.memory.heap.max

--- a/ambari-metrics-timelineservice/src/main/resources/metrics_def/AMBARI_SERVER.dat
+++ b/ambari-metrics-timelineservice/src/main/resources/metrics_def/AMBARI_SERVER.dat
@@ -5,10 +5,10 @@ jvm.buffers.mapped.capacity
 jvm.buffers.mapped.count
 jvm.buffers.mapped.used
 jvm.file.open.descriptor.ratio
-jvm.gc.ConcurrentMarkSweep.count
-jvm.gc.ConcurrentMarkSweep.time
-jvm.gc.ParNew.count
-jvm.gc.ParNew.time
+jvm.gc.G1 Old Generation.count
+jvm.gc.G1 Old Generation.time
+jvm.gc.G1 Young Generation.count
+jvm.gc.G1 Young Generation.time
 jvm.memory.heap.committed
 jvm.memory.heap.init
 jvm.memory.heap.max

--- a/ambari-metrics-timelineservice/src/main/resources/metrics_def/AMS-HBASE.dat
+++ b/ambari-metrics-timelineservice/src/main/resources/metrics_def/AMS-HBASE.dat
@@ -2,10 +2,10 @@ regionserver.WAL.SyncTime_min
 regionserver.WAL.SyncTime_num_ops
 regionserver.WAL.appendCount
 regionserver.WAL.slowAppendCount
-jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcCountG1 Young Generation
 jvm.JvmMetrics.GcTimeMillis
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
 ugi.UgiMetrics.GetGroupsAvgTime
 ugi.UgiMetrics.GetGroupsNumOps
 ugi.UgiMetrics.LoginFailureNumOps
@@ -197,7 +197,7 @@ regionserver.Server.checkMutateFailedCount
 regionserver.Server.checkMutatePassedCount
 regionserver.Server.compactionQueueLength
 regionserver.Server.flushQueueLength
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
+jvm.JvmMetrics.GcCountG1 Old Generation
 regionserver.Server.hlogFileCount
 regionserver.Server.hlogFileSize
 regionserver.Server.memStoreSize

--- a/ambari-metrics-timelineservice/src/main/resources/metrics_def/DATANODE.dat
+++ b/ambari-metrics-timelineservice/src/main/resources/metrics_def/DATANODE.dat
@@ -95,13 +95,13 @@ dfs.datanode.WriteBlockOpNumOps
 dfs.datanode.WritesFromLocalClient
 dfs.datanode.WritesFromRemoteClient
 jvm.JvmMetrics.GcCount
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
-jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcCountG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Young Generation
 jvm.JvmMetrics.GcNumInfoThresholdExceeded
 jvm.JvmMetrics.GcNumWarnThresholdExceeded
 jvm.JvmMetrics.GcTimeMillis
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
 jvm.JvmMetrics.GcTotalExtraSleepTime
 jvm.JvmMetrics.LogError
 jvm.JvmMetrics.LogFatal

--- a/ambari-metrics-timelineservice/src/main/resources/metrics_def/HBASE_MASTER.dat
+++ b/ambari-metrics-timelineservice/src/main/resources/metrics_def/HBASE_MASTER.dat
@@ -26,11 +26,11 @@ ipc.IPC.queueSize
 ipc.IPC.receivedBytes 
 ipc.IPC.sentBytes 
 jvm.Master.JvmMetrics.GcCount
-jvm.Master.JvmMetrics.GcCountConcurrentMarkSweep
-jvm.Master.JvmMetrics.GcCountParNew
+jvm.Master.JvmMetrics.GcCountG1 Old Generation
+jvm.Master.JvmMetrics.GcCountG1 Young Generation
 jvm.Master.JvmMetrics.GcTimeMillis
-jvm.Master.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.Master.JvmMetrics.GcTimeMillisParNew
+jvm.Master.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.Master.JvmMetrics.GcTimeMillisG1 Young Generation
 jvm.Master.JvmMetrics.LogError
 jvm.Master.JvmMetrics.LogFatal
 jvm.Master.JvmMetrics.LogInfo

--- a/ambari-metrics-timelineservice/src/main/resources/metrics_def/HBASE_REGIONSERVER.dat
+++ b/ambari-metrics-timelineservice/src/main/resources/metrics_def/HBASE_REGIONSERVER.dat
@@ -26,11 +26,11 @@ ipc.IPC.queueSize
 ipc.IPC.receivedBytes 
 ipc.IPC.sentBytes 
 jvm.RegionServer.JvmMetrics.GcCount
-jvm.RegionServer.JvmMetrics.GcCountConcurrentMarkSweep
-jvm.RegionServer.JvmMetrics.GcCountParNew
+jvm.RegionServer.JvmMetrics.GcCountG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcCountG1 Young Generation
 jvm.RegionServer.JvmMetrics.GcTimeMillis
-jvm.RegionServer.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.RegionServer.JvmMetrics.GcTimeMillisParNew
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.RegionServer.JvmMetrics.GcTimeMillisG1 Young Generation
 jvm.RegionServer.JvmMetrics.LogError
 jvm.RegionServer.JvmMetrics.LogFatal
 jvm.RegionServer.JvmMetrics.LogInfo

--- a/ambari-metrics-timelineservice/src/main/resources/metrics_def/NAMENODE.dat
+++ b/ambari-metrics-timelineservice/src/main/resources/metrics_def/NAMENODE.dat
@@ -267,13 +267,13 @@ dfs.namenode.TransactionsAvgTime
 dfs.namenode.TransactionsBatchedInSync
 dfs.namenode.TransactionsNumOps
 jvm.JvmMetrics.GcCount
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
-jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcCountG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Young Generation
 jvm.JvmMetrics.GcNumInfoThresholdExceeded
 jvm.JvmMetrics.GcNumWarnThresholdExceeded
 jvm.JvmMetrics.GcTimeMillis
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
 jvm.JvmMetrics.GcTotalExtraSleepTime
 jvm.JvmMetrics.LogError
 jvm.JvmMetrics.LogFatal

--- a/ambari-metrics-timelineservice/src/test/resources/test_data/full_whitelist.dat
+++ b/ambari-metrics-timelineservice/src/test/resources/test_data/full_whitelist.dat
@@ -60,8 +60,8 @@ regionserver.WAL.SyncTime_num_ops
 regionserver.WAL.appendCount
 regionserver.WAL.slowAppendCount
 jvm.JvmMetrics.GcTimeMillis
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
 ugi.UgiMetrics.GetGroupsAvgTime
 ugi.UgiMetrics.GetGroupsNumOps
 ugi.UgiMetrics.LoginFailureNumOps
@@ -253,7 +253,7 @@ regionserver.Server.checkMutateFailedCount
 regionserver.Server.checkMutatePassedCount
 regionserver.Server.compactionQueueLength
 regionserver.Server.flushQueueLength
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
+jvm.JvmMetrics.GcCountG1 Old Generation
 regionserver.Server.hlogFileCount
 regionserver.Server.hlogFileSize
 regionserver.Server.memStoreSize
@@ -284,7 +284,7 @@ regionserver.WAL.AppendSize_max
 regionserver.WAL.AppendSize_mean
 regionserver.WAL.AppendSize_median
 regionserver.WAL.SyncTime_median
-jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcCountG1 Young Generation
 regionserver.WAL.AppendSize_min
 regionserver.WAL.AppendSize_num_ops
 regionserver.WAL.SyncTime_max
@@ -322,8 +322,8 @@ regionserver.WAL.SyncTime_num_ops
 regionserver.WAL.appendCount
 regionserver.WAL.slowAppendCount
 jvm.JvmMetrics.GcTimeMillis
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
 ugi.UgiMetrics.GetGroupsAvgTime
 ugi.UgiMetrics.GetGroupsNumOps
 ugi.UgiMetrics.LoginFailureNumOps
@@ -515,7 +515,7 @@ regionserver.Server.checkMutateFailedCount
 regionserver.Server.checkMutatePassedCount
 regionserver.Server.compactionQueueLength
 regionserver.Server.flushQueueLength
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
+jvm.JvmMetrics.GcCountG1 Old Generation
 regionserver.Server.hlogFileCount
 regionserver.Server.hlogFileSize
 regionserver.Server.memStoreSize
@@ -546,7 +546,7 @@ regionserver.WAL.AppendSize_max
 regionserver.WAL.AppendSize_mean
 regionserver.WAL.AppendSize_median
 regionserver.WAL.SyncTime_median
-jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcCountG1 Young Generation
 regionserver.WAL.AppendSize_min
 regionserver.WAL.AppendSize_num_ops
 regionserver.WAL.SyncTime_max
@@ -585,7 +585,7 @@ regionserver.WAL.SyncTime_mean
 regionserver.WAL.AppendSize_99th_percentile
 jvm.JvmMetrics.GcTimeMillis
 regionserver.WAL.AppendSize_75th_percentile
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
 regionserver.WAL.SyncTime_max
 regionserver.Server.Increment_median
 regionserver.Server.updatesBlockedTime
@@ -595,7 +595,7 @@ regionserver.WAL.lowReplicaRollRequest
 ugi.UgiMetrics.GetGroupsNumOps
 regionserver.Server.storeFileSize
 regionserver.Server.Increment_95th_percentile
-jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
 ugi.UgiMetrics.LoginFailureAvgTime
 ugi.UgiMetrics.LoginFailureNumOps
 regionserver.Server.storeFileCount
@@ -885,7 +885,7 @@ regionserver.Server.compactionQueueLength
 regionserver.Server.flushedCellsSize
 regionserver.Server.memStoreSize
 regionserver.Server.mutationsWithoutWALSize
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
+jvm.JvmMetrics.GcCountG1 Old Generation
 regionserver.Server.regionServerStartTime
 regionserver.Server.slowDeleteCount
 regionserver.Server.slowIncrementCount
@@ -903,7 +903,7 @@ regionserver.Server.Replay_95th_percentile
 regionserver.WAL.AppendTime_95th_percentile
 regionserver.WAL.AppendTime_median
 regionserver.WAL.AppendTime_max
-jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcCountG1 Young Generation
 regionserver.WAL.AppendTime_mean
 FSDatasetState.org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetImpl.CacheCapacity
 FSDatasetState.org.apache.hadoop.hdfs.server.datanode.fsdataset.impl.FsDatasetImpl.CacheUsed
@@ -1100,13 +1100,13 @@ dfs.namenode.TransactionsAvgTime
 dfs.namenode.TransactionsBatchedInSync
 dfs.namenode.TransactionsNumOps
 jvm.JvmMetrics.GcCount
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
-jvm.JvmMetrics.GcCountParNew
+jvm.JvmMetrics.GcCountG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Young Generation
 jvm.JvmMetrics.GcNumInfoThresholdExceeded
 jvm.JvmMetrics.GcNumWarnThresholdExceeded
 jvm.JvmMetrics.GcTimeMillis
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.JvmMetrics.GcTimeMillisParNew
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcTimeMillisG1 Young Generation
 jvm.JvmMetrics.GcTotalExtraSleepTime
 jvm.JvmMetrics.LogError
 jvm.JvmMetrics.LogFatal

--- a/ambari-metrics-timelineservice/src/test/resources/ui_metrics_def/NAMENODE.dat
+++ b/ambari-metrics-timelineservice/src/test/resources/ui_metrics_def/NAMENODE.dat
@@ -21,8 +21,8 @@ dfs.FSNamesystem.UnderReplicatedBlocks
 ||
 rpc.rpc.NumOpenConnections
 rpc.rpc.RpcQueueTimeAvgTime
-jvm.JvmMetrics.GcTimeMillisConcurrentMarkSweep
-jvm.JvmMetrics.GcCountConcurrentMarkSweep
+jvm.JvmMetrics.GcTimeMillisG1 Old Generation
+jvm.JvmMetrics.GcCountG1 Old Generation
 jvm.JvmMetrics.MemHeapCommittedM
 rpc.rpc.RpcProcessingTimeAvgTime
 jvm.JvmMetrics.MemHeapUsedM


### PR DESCRIPTION
AMBARI-26313: Change metrics names in grafana dashboards as per the GC used in JDK17

## What changes were proposed in this pull request?
Changing metrics names according to GC used in JDK17

(Please fill in changes proposed in this fix)

## How was this patch tested?
Tested on local cluster. attaching screenshots.

![image](https://github.com/user-attachments/assets/ccdb1caf-1580-43c5-9570-5f94d2e5d9d6)
![image](https://github.com/user-attachments/assets/fcd2963f-5e5c-488b-8dbd-cb638fd4e9c6)
![image](https://github.com/user-attachments/assets/5d572f9a-003b-405c-89d4-791a3468e688)
![image](https://github.com/user-attachments/assets/dd55b97f-6630-4132-b0eb-74364bcfa9e5)

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
