### PR TITLE
Fix ambari-metrics-grafana start scipt only check pid file exist.

### DIFF
--- a/ambari-metrics-grafana/conf/unix/ambari-metrics-grafana
+++ b/ambari-metrics-grafana/conf/unix/ambari-metrics-grafana
@@ -89,7 +89,22 @@ fi
 DAEMON_OPTS="--pidfile=${PID_FILE} --config=${CONF_FILE} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR}"
 
 function isRunning() {
-  test -e "$PID_FILE"
+  if [ -f ${PID_FILE} ]; then
+    PID=`cat ${PID_FILE}`
+    if [ -z "`ps ax -o pid | grep -w ${PID}`" ]; then
+      echo "${PID_FILE} found with no process. Removing ${PID}..."
+      rm -f ${PID_FILE}
+      return 1
+    else
+      tput bold
+      echo "WARN: Grafana already running with PID: ${PID}"
+      tput sgr0
+      echo "Exiting."
+      return 0
+    fi
+  else
+    return 1
+  fi
 }
 
 case "$1" in


### PR DESCRIPTION
  Fix ambari-metrics-grafana start scipt only check pid file exist.
  This commit fixes a bug where when the metrics-grafana service was stopped outside the Ambari interface, attempting to start Grafana through the Ambari interface would incorrectly report the service as already running while Grafana had actually failed to start. The resolution addresses this state mismatch and ensures proper service status synchronization.
