### PR TITLE
AMBARI-26477: Ambari-metrics precommit must migrate away from Ubuntu 20.04

### DIFF
--- a/.github/workflows/ambari.yml
+++ b/.github/workflows/ambari.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics-timelineservice/pom.xml
@@ -228,6 +228,7 @@
           <excludes>
             <exclude>conf/unix/metrics_whitelist</exclude>
             <exclude>conf/unix/amshbase_metrics_whitelist</exclude>
+            <exclude>ignite/work/**</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari-metrics use GitHub Action Ubutnu 20.04 workers but the runner image is no longer available after April 15th. This pull request change updating the .github/workflows/ambari.yml file to set runs-on: ubuntu-22.04.

## How was this patch tested?
mvn dependency:tree
