### PR TITLE
AMBARI-26487: Bump commons-io:commons-io from 2.4 to 2.14.0 in /ambari-metrics-common

### DIFF
--- a/ambari-metrics-common/pom.xml
+++ b/ambari-metrics-common/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump commons-io:commons-io from 2.4 to 2.14.0 in /ambari-metrics-common

## How was this patch tested?
cd ambari-metrics-common
mvn test
mvn dependency:tree -DignoreErrors | grep commons-io
mvn dependency:tree -DignoreErrors