### PR TITLE
AMBARI-26486: Bump org.apache.helix:helix-core from 0.6.6 to 1.3.0 in /ambari-metrics-timelineservice

### DIFF
--- a/ambari-metrics-timelineservice/pom.xml
+++ b/ambari-metrics-timelineservice/pom.xml
@@ -269,7 +269,7 @@
     <dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
-      <version>0.6.6</version>
+      <version>1.3.0</version>
       <exclusions>
         <!-- zkclient is helix-core dependency but it need to be 0.9 in order for AMS HA to work on secure cluster-->
         <exclusion>


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

Bump org.apache.helix:helix-core from 0.6.6 to 1.3.0 in /ambari-metrics-timelineservice

## How was this patch tested?
cd ambari-metrics-timelineservice
mvn test
mvn dependency:tree -DignoreErrors | grep helix-core
mvn dependency:tree -DignoreErrors