### PR TITLE
AMBARI-26493: Update jackson2 version to 2.12.7 in ambari-metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,8 @@
     <distMgmtStagingId>apache.staging.https</distMgmtStagingId>
     <distMgmtStagingName>Apache Release Distribution Repository</distMgmtStagingName>
     <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
-    <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.12.7</fasterxml.jackson.version>
+    <fasterxml.jackson-databind.version>2.12.7.1</fasterxml.jackson-databind.version>
     <skipPythonTests>false</skipPythonTests>
     <release.version>1</release.version>
   </properties>
@@ -102,7 +103,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${fasterxml.jackson.version}</version>
+        <version>${fasterxml.jackson-databind.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
<!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->

## What changes were proposed in this pull request?

Update jackson2 2.12.7 / jackson2 databind 2.12.7.1 which are the oldest version without CVEs.

## How was this patch tested?

Build

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
